### PR TITLE
added default value for DEV in axis configuration.

### DIFF
--- a/scripts/configureAxis.cmd
+++ b/scripts/configureAxis.cmd
@@ -8,7 +8,7 @@
 #-d   \author Niko Kivel
 #-d   \file
 #-d   \param CONFIG configuration file, i.e. ./cfg/linear_1.pax
-#-d   \param DEV (optinal) device name, i.e. MOTOR1
+#-d   \param DEV (optional) device name, i.e. MOTOR1
 #-d   \note Example call:
 #-d   \code
 #-d     ${SCRIPTEXEC} ${ecmccfg_DIR}configureAxis.cmd,            "CONFIG=./cfg/linear_1.pax"

--- a/scripts/configureVirtualAxis.cmd
+++ b/scripts/configureVirtualAxis.cmd
@@ -8,7 +8,7 @@
 #-d   \author Niko Kivel
 #-d   \file
 #-d   \param CONFIG configuration file, i.e. ./cfg/linear_11.vax
-#-d   \param DEV (optinal) device name, i.e. GAP
+#-d   \param DEV (optional) device name, i.e. GAP
 #-d   \note Example call:
 #-d   \code
 #-d     ${SCRIPTEXEC} ${ecmccfg_DIR}configureVirtualAxis.cmd,     "CONFIG=./cfg/linear_11.vax"


### PR DESCRIPTION
Next improvement. Default value for DEV, used by configureAxis.cmd and configureVirtualAxis.cmd.
The default value is ${IOC}, which is mandatory anyway. From your examples I gather that this is what you set as default?