### PR TITLE
Anders macro in plc

### DIFF
--- a/examples/test/plc/ecMacroExample.plc
+++ b/examples/test/plc/ecMacroExample.plc
@@ -1,0 +1,39 @@
+###############################################################################################
+# For help on syntax, variables and functions, please read the file: "plcSyntaxHelp.plc"
+#
+# PLC Functionality Demo:
+#
+#  Code Description:
+#    1. Test Macros (parse with msi):
+#       - PLC_ID  optional, default "0"
+#       - SLAVE_ID  optional, default "2"
+#       - DBG optional, defaults to "#" 
+
+if(plc${PLC_ID=0}.firstscan) {
+  ${DBG=#}println('First Scan');
+};
+
+#Flash outputs
+ec0.s${SLAVE_ID=2}.OUPIN_1:=ec_flp_bit(ec0.s${SLAVE_ID=2}.OUPIN_1,0);
+ec0.s${SLAVE_ID=2}.OUPIN_2:=ec_flp_bit(ec0.s${SLAVE_ID=2}.OUPIN_2,0);
+ec0.s${SLAVE_ID=2}.OUPIN_3:=ec_flp_bit(ec0.s${SLAVE_ID=2}.OUPIN_3,0);
+ec0.s${SLAVE_ID=2}.OUPIN_4:=ec_flp_bit(ec0.s${SLAVE_ID=2}.OUPIN_4,0);
+
+ec0.s${SLAVE_ID=2}.OUPIN_5:=not(ec0.s${SLAVE_ID=2}.OUPIN_1);
+ec0.s${SLAVE_ID=2}.OUPIN_6:=not(ec0.s${SLAVE_ID=2}.OUPIN_2);
+ec0.s${SLAVE_ID=2}.OUPIN_7:=not(ec0.s${SLAVE_ID=2}.OUPIN_3);
+ec0.s${SLAVE_ID=2}.OUPIN_8:=not(ec0.s${SLAVE_ID=2}.OUPIN_4);
+
+# Assemble the complete byte (to test ec_wrt_bit() command)
+static.outputByte:=ec_wrt_bit(static.outputByte,ec0.s${SLAVE_ID=2}.OUPIN_1,0);
+static.outputByte:=ec_wrt_bit(static.outputByte,ec0.s${SLAVE_ID=2}.OUPIN_2,1);
+static.outputByte:=ec_wrt_bit(static.outputByte,ec0.s${SLAVE_ID=2}.OUPIN_3,2);
+static.outputByte:=ec_wrt_bit(static.outputByte,ec0.s${SLAVE_ID=2}.OUPIN_4,3);
+static.outputByte:=ec_wrt_bit(static.outputByte,ec0.s${SLAVE_ID=2}.OUPIN_5,4);
+static.outputByte:=ec_wrt_bit(static.outputByte,ec0.s${SLAVE_ID=2}.OUPIN_6,5);
+static.outputByte:=ec_wrt_bit(static.outputByte,ec0.s${SLAVE_ID=2}.OUPIN_7,6);
+static.outputByte:=ec_wrt_bit(static.outputByte,ec0.s${SLAVE_ID=2}.OUPIN_8,7);
+${DBG=#}print('Output byte value: ');
+${DBG=#}ec_print_bin(static.outputByte,0,7);
+${DBG=#}println('');
+

--- a/examples/test/plc/homeBackForwSeq.plc
+++ b/examples/test/plc/homeBackForwSeq.plc
@@ -6,7 +6,7 @@
 #   Code Description:
 #     1. Enable power on axis (mc_power())
 #     2. Home at startup if needed (mc_home())
-#     3. Move to position 130 (mc_move_abs())
+#     3. Move to position 120 (mc_move_abs())
 #     4. Move to position -10 (mc_move_abs())
 #     5. Stop sequence if limit switch violation or errorCode on motion blocks
 #     
@@ -70,7 +70,7 @@ if(static.seqStep==2)
 ##### 3. Trigger a absolute move 
 if(static.seqStep==3){
   ax1.blockcom:=0;  #Allow EPICS control
-  var posTarg:=130;
+  var posTarg:=120;
   var vel:=50;
   var acc:=100;
   var dec:=100;
@@ -102,7 +102,7 @@ if(static.seqStep==4){
   {
     mc_move_abs(1,0,posTarg,vel,acc,dec);  # Set execute low
     static.seqStep:=3;
-    println('3. Function mc_move_abs(1,1,130,50,100,100) triggered!');
+    println('3. Function mc_move_abs(1,1,120,50,100,100) triggered!');
     static.cycleCounter:=static.cycleCounter+1;
     println('Cycles:  ',static.cycleCounter);  # See if axis 1 is busy
   };

--- a/examples/test/plc/homeBackForwSeqEncLatch.plc
+++ b/examples/test/plc/homeBackForwSeqEncLatch.plc
@@ -6,7 +6,7 @@
 #   Code Description:
 #     1. Enable power on axis (mc_power())
 #     2. Home at startup if needed (mc_home())
-#     3. Move to position 130 (mc_move_abs())
+#     3. Move to position 120 (mc_move_abs())
 #     4. Move to position -10 (mc_move_abs())
 #     5. Stop sequence if limit switch violation or errorCode on motion blocks
 #     
@@ -71,7 +71,7 @@ if(static.seqStep==2)
 if(static.seqStep==3){
   ec0.s3.ENC_CONTROL:=ec_clr_bit(ec0.s3.ENC_CONTROL,0);  #Set/reset latch on C  
   ax1.blockcom:=0;  #Allow EPICS control
-  var posTarg:=130;
+  var posTarg:=120;
   var vel:=50;
   var acc:=100;
   var dec:=100;
@@ -104,7 +104,7 @@ if(static.seqStep==4){
   {
     mc_move_abs(1,0,posTarg,vel,acc,dec);  # Set execute low
     static.seqStep:=3;
-    println('3. Function mc_move_abs(1,1,130,50,100,100) triggered!');
+    println('3. Function mc_move_abs(1,1,120,50,100,100) triggered!');
     static.cycleCounter:=static.cycleCounter+1;
     println('Cycles:  ',static.cycleCounter);  # See if axis 1 is busy
   };

--- a/examples/test/plcMCU1012TestMacro.script
+++ b/examples/test/plcMCU1012TestMacro.script
@@ -1,0 +1,63 @@
+##############################################################################
+## Example config for PLC controlled sequence:
+#     1. Enable power on axis (mc_power())
+#     2. Home at startup if needed (mc_home())
+#     3. Move to position 130 (mc_move_abs())
+#     4. Move to position -10 (mc_move_abs())
+#     5. Stop sequence if limit switch violation or errorCode on motion blocks
+#     6. Latch data on incremental encoder index pulse
+
+##############################################################################
+## Initiation:
+epicsEnvSet("IOC" ,"$(IOC="IOC_TEST")")
+epicsEnvSet("ECMCCFG_INIT" ,"")  #Only run startup once (auto at PSI, need call at ESS), variable set to "#" in startup.cmd
+#epicsEnvSet("SCRIPTEXEC" ,"$(SCRIPTEXEC="iocshLoad")")
+epicsEnvSet("SCRIPTEXEC" ,"$(SCRIPTEXEC="loadIocsh")")
+
+require ecmccfg develop
+
+# run module startup.cmd (only needed at ESS  PSI auto call at require)
+$(ECMCCFG_INIT)$(SCRIPTEXEC) ${ecmccfg_DIR}startup.cmd, "IOC=$(IOC),ECMC_VER=develop,EthercatMC_VER=3.0.0,stream_VER=2.7.14p"
+
+##############################################################################
+## Configure hardware:
+$(SCRIPTEXEC) $(ecmccfg_DIR)ecmcMCU1012.cmd
+
+# ADDITIONAL SETUP
+# Set all outputs to feed switches
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},OUPIN_1,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},OUPIN_2,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},OUPIN_3,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},OUPIN_4,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},OUPIN_5,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},OUPIN_6,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},OUPIN_7,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},OUPIN_8,1)"
+# END of ADDITIONAL SETUP
+
+##############################################################################
+## AXIS 1
+#
+epicsEnvSet("DEV",      "$(IOC)")
+$(SCRIPTEXEC) ($(ecmccfg_DIR)configureAxis.cmd, CONFIG=./cfg/mcu1012_1.ax)
+
+##############################################################################
+## Data Storage 1
+$(SCRIPTEXEC) $(ecmccfg_DIR)addDataStorage.cmd "DS_ID=1, DS_SIZE=100, SAMPLE_RATE_MS=-1, DS_TYPE=2")
+
+##############################################################################
+## PLC 1
+$(SCRIPTEXEC) $(ecmccfg_DIR)loadPLCFile.cmd, "PLC_ID=0, SAMPLE_RATE_MS=100,FILE=./plc/ecMacroExample.plc, PLC_MACROS='PLC_ID=0,SLAVE_ID=2,DBG='")
+
+##############################################################################
+############# Configure diagnostics:
+
+ecmcConfigOrDie "Cfg.EcSetDiagnostics(1)"
+ecmcConfigOrDie "Cfg.EcEnablePrintouts(0)"
+ecmcConfigOrDie "Cfg.EcSetDomainFailedCyclesLimit(100)"
+ecmcConfigOrDie "Cfg.SetDiagAxisIndex(1)"
+ecmcConfigOrDie "Cfg.SetDiagAxisFreq(2)"
+ecmcConfigOrDie "Cfg.SetDiagAxisEnable(0)"
+
+# go active
+$(SCRIPTEXEC) ($(ecmccfg_DIR)setAppMode.cmd)

--- a/scripts/loadPLCFile.cmd
+++ b/scripts/loadPLCFile.cmd
@@ -1,6 +1,6 @@
 #==============================================================================
 # loadPLCFile.cmd
-#- Arguments: FILE, [PLC_ID], [SAMPLE_RATE_MS]
+#- Arguments: FILE, [PLC_ID], [SAMPLE_RATE_MS], [PLC_MACROS]
 
 #-d /**
 #-d   \brief Script for adding a PLC from file.
@@ -10,6 +10,7 @@
 #-d   \param FILE PLC definition file, i.e. ./plc/homeSlit.plc
 #-d   \param PLC_ID (optional) PLC number, default 0
 #-d   \param SAMPLE_RATE_MS (optional) excecution rate, default 1 ms (realtime)
+#-d   \param PLC_MACROS (optional) Substitution macros for PLC code
 #-d   \note Example call:
 #-d   \code
 #-d     ${SCRIPTEXEC} ${ecmccfg_DIR}loadPLCFile.cmd, "PLC_ID=0, FILE=./plc/homeSlit.plc, SAMPLE_RATE_MS=100"
@@ -20,7 +21,12 @@
 
 epicsEnvSet("ECMC_PLC_ID",          "${PLC_ID=0}")
 epicsEnvSet("ECMC_PLC_SAMPLE_RATE_MS","${SAMPLE_RATE_MS=1}") # execute at 1000Hz
+epicsEnvSet("ECMC_PLC_MACROS","${PLC_MACROS=EMPTY}")
+
+#Convert file with optional macros (msi)
+system "msi -V -M ${ECMC_PLC_MACROS} ${FILE} > ${FILE}_msi"
 ecmcConfigOrDie "Cfg.CreatePLC(${ECMC_PLC_ID},${ECMC_PLC_SAMPLE_RATE_MS})"
-ecmcConfigOrDie "Cfg.LoadPLCFile(${ECMC_PLC_ID},${FILE})"
+ecmcConfigOrDie "Cfg.LoadPLCFile(${ECMC_PLC_ID},${FILE}_msi)"
 
 dbLoadRecords("ecmcPlc.db", "PORT=${ECMC_ASYN_PORT},A=0,Index=${ECMC_PLC_ID},Name=${ECMC_PREFIX}")
+

--- a/scripts/loadPLCFile.cmd
+++ b/scripts/loadPLCFile.cmd
@@ -23,10 +23,14 @@ epicsEnvSet("ECMC_PLC_ID",          "${PLC_ID=0}")
 epicsEnvSet("ECMC_PLC_SAMPLE_RATE_MS","${SAMPLE_RATE_MS=1}") # execute at 1000Hz
 epicsEnvSet("ECMC_PLC_MACROS","${PLC_MACROS=EMPTY}")
 
-#Convert file with optional macros (msi)
+#-Convert file with optional macros (msi)
+
 system "msi -V -M ${ECMC_PLC_MACROS} ${FILE} > ${FILE}_msi"
 ecmcConfigOrDie "Cfg.CreatePLC(${ECMC_PLC_ID},${ECMC_PLC_SAMPLE_RATE_MS})"
 ecmcConfigOrDie "Cfg.LoadPLCFile(${ECMC_PLC_ID},${FILE}_msi)"
+
+#-Remove parsed file after load
+system "rm ${FILE}_msi"
 
 dbLoadRecords("ecmcPlc.db", "PORT=${ECMC_ASYN_PORT},A=0,Index=${ECMC_PLC_ID},Name=${ECMC_PREFIX}")
 


### PR DESCRIPTION
@kivel , I added a feature to allow macros in plc files. Allows development of more generic plc-code and for instance to block printouts.
See "examples/test/plc/ecMacroExample.plc"

The "msi" parser is used to parse the plc files. Is this a to "uggly" or "risky" approach, not sure myself? But I think for sure the feature could be usefull.

Please check it out and tell me what you think!




