### PR TITLE
allow for local slave configuration

### DIFF
--- a/scripts/applySlaveConfig.cmd
+++ b/scripts/applySlaveConfig.cmd
@@ -1,7 +1,6 @@
 #===============================================================================
 # applySlaveConfig.cmd
-# Arguments: CONFIG
-# apply config ${CONFIG} for ${HW_DESC} at the bus at position ${SLAVE_ID}
+# Arguments: CONFIG _or_ LOCAL_CONFIG
 
 #-d /**
 #-d   \brief Script for applying a specific slave configuration after the slave had been added manually.
@@ -12,8 +11,15 @@
 #-d   \code
 #-d     ${SCRIPTEXEC} ${ecmccfg_DIR}applySlaveConfig.cmd, "CONFIG=-Motor-Nanotec-ST4118L1804-B"
 #-d   \endcode
+#-d   \note call applySlaveConfig with LOCAL_CONFIG
+#-d   \code
+#-d     ${SCRIPTEXEC} ${ecmccfg_DIR}applySlaveConfig.cmd, "LOCAL_CONFIG=./myFancyServoConfig.cfg"
+#-d   \endcode
 #-d */
 #-d   \pre A slave has to added immediately before this script is called by \b addSlave.cmd.
 
-ecmcFileExist("${ECMC_CONFIG_ROOT}ecmc${HW_DESC}${CONFIG}.cmd",1)
-${SCRIPTEXEC} ${ECMC_CONFIG_ROOT}ecmc${HW_DESC}${CONFIG}.cmd
+#- use LOCAL_CONFIG, else use CONFIG which has to be in ECMC_CONFIG_ROOT
+epicsEnvSet("ECMC_CONFIG_FN", "${LOCAL_CONFIG=${ECMC_CONFIG_ROOT}ecmc${HW_DESC}${CONFIG}.cmd}")
+
+ecmcFileExist("${ECMC_CONFIG_FN}",1)
+${SCRIPTEXEC} ${ECMC_CONFIG_FN}


### PR DESCRIPTION
allow to load a config file that's not in `ECMC_CFG_ROOT`, also w/o the **ecmc** prefix and **HWType**