### PR TITLE
aSub for timestamping records with EtherCAT time

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -40,3 +40,5 @@ TEMPLATES+=$(wildcard ./db/*/*.template)
 TEMPLATES+=$(wildcard ./db/*/*.substitutions)
 TEMPLATES+=$(wildcard ./db/*/*.subs)
 
+SOURCES += $(wildcard ./src/*.cpp)
+DBDS    += $(wildcard ./dbd/*.dbd)

--- a/db/Beckhoff_1XXX/ecmcEL1252.template
+++ b/db/Beckhoff_1XXX/ecmcEL1252.template
@@ -7,6 +7,17 @@ record(ai,"$(P)ec$(MASTER_ID)-s$(SLAVE_POS)-$(HWTYPE)-CH$(CH_ID)-PosTime-Act"){
   field(TSE,  "$(TSE=-2)")
   field(PREC, "0" )
   field(EGU,  "ns" )
+  field(FLNK, "$(P)ec$(MASTER_ID)-s$(SLAVE_POS)-$(HWTYPE)-CH$(CH_ID)-PosTimestamp.PROC")
+}
+
+record(aSub,  "$(P)ec$(MASTER_ID)-s$(SLAVE_POS)-$(HWTYPE)-CH$(CH_ID)-PosTimestamp") {
+  field(DESC,  "ECAT timestamp")
+  field(INAM,  "ECATtimestampInit")
+  field(SNAM,  "ECATtimestamp")
+  field(INPA,  "$(P)ec$(MASTER_ID)-s$(SLAVE_POS)-$(HWTYPE)-CH$(CH_ID)-PosTime-Act")
+  field(FTA,   "DOUBLE")
+  field(NOA,   1)
+  field(TSE,  -2)
 }
 
 record(ai,"$(P)ec$(MASTER_ID)-s$(SLAVE_POS)-$(HWTYPE)-CH$(CH_ID)-NegTime-Act"){
@@ -18,6 +29,17 @@ record(ai,"$(P)ec$(MASTER_ID)-s$(SLAVE_POS)-$(HWTYPE)-CH$(CH_ID)-NegTime-Act"){
   field(TSE,  "$(TSE=-2)")
   field(PREC, "0" )
   field(EGU,  "ns" )
+  field(FLNK, "$(P)ec$(MASTER_ID)-s$(SLAVE_POS)-$(HWTYPE)-CH$(CH_ID)-NegTimestamp.PROC")
+}
+
+record(aSub,  "$(P)ec$(MASTER_ID)-s$(SLAVE_POS)-$(HWTYPE)-CH$(CH_ID)-NegTimestamp") {
+  field(DESC,  "ECAT timestamp")
+  field(INAM,  "ECATtimestampInit")
+  field(SNAM,  "ECATtimestamp")
+  field(INPA,  "$(P)ec$(MASTER_ID)-s$(SLAVE_POS)-$(HWTYPE)-CH$(CH_ID)-NegTime-Act")
+  field(FTA,   "DOUBLE")
+  field(NOA,   1)
+  field(TSE,  -2)
 }
 
 record(mbbiDirect,"$(P)ec$(MASTER_ID)-s$(SLAVE_POS)-$(HWTYPE)-CH$(CH_ID)-Stat"){

--- a/dbd/ECATtimestamp.dbd
+++ b/dbd/ECATtimestamp.dbd
@@ -1,0 +1,2 @@
+function(ECATtimestampInit)
+function(ECATtimestamp)

--- a/src/ECATtimestamp.cpp
+++ b/src/ECATtimestamp.cpp
@@ -1,0 +1,61 @@
+// aSub, EPICS related headers
+#include <aSubRecord.h>
+#include <registryFunction.h>
+#include <epicsExport.h>
+// std::cout
+#include <iostream>
+// split double into fractional and integer
+#include <math.h>
+
+// declare init function
+static long ECATtimestampInit(struct aSubRecord *rec);
+epicsRegisterFunction(ECATtimestampInit);
+
+// declare worker function
+static long ECATtimestamp(struct aSubRecord *rec);
+epicsRegisterFunction(ECATtimestamp);
+
+// init (INAM)
+static long ECATtimestampInit(struct aSubRecord *rec){
+  std::cout << "ECATtimestamp aSubRecord: "<< rec->name << std::endl;
+  return 0;
+}
+
+// work (SNAM)
+static long ECATtimestamp(struct aSubRecord *rec){
+
+	/*
+			timestamp from EtherCAT has epoch 2000-01-01 00:00 UTC
+	 		UNIX epoch offset --> 946684800 s
+			value in nanoseconds
+	*/
+	double ECMC_timestamp	= *((double *)rec->a);
+	ECMC_timestamp /= 1000000000;                           // scale to seconds
+  ECMC_timestamp += 946684800-POSIX_TIME_AT_EPICS_EPOCH;  // apply offset
+	// split integer and fractional seconds
+	double integer, fractional;
+	fractional = modf(ECMC_timestamp, &integer);
+
+	// EPICS timestamp struct
+	epicsTimeStamp t;
+	t.secPastEpoch=(unsigned long)integer;
+	t.nsec=(unsigned long)(fractional*1000000000);
+	// set record timestamp, needs TSE=-2
+	rec->time = t;
+  // return nanosecond part of timestamp
+  return t.nsec;
+}
+
+/*
+--------------------------------------------------------------------------------
+EPICS database example
+record(aSub,  "${SYS}:ECATtimestamp") {
+  field(DESC,  "ECAT timestamp")
+  field(INAM,  "ECATtimestampInit")
+  field(SNAM,  "ECATtimestamp")
+  field(FTA,   "DOUBLE")
+  field(NOA,   1)
+  field(TSE,  -2)
+}
+--------------------------------------------------------------------------------
+*/


### PR DESCRIPTION
@anderssandstrom, as mentioned earlier this is the first idea to get a records stamped with EtherCAT time.
I suggest that records that need to receive a timestamp other than the asyn ts, will `CP` to the '{Pos|Neg}Timestamp' with TSE=-1 and TSEL set.
Such records will most likely only be post processing records. Therefore I see no reason to change any of the ECMC internal records to have special timestamps. They should stay on the time the frame left the master. This is also beneficial for diagnosing problems, as all internal records have only one timestamp per cycle, with the exception of the new, dedicated timestamp records of course.