### PR TITLE
Add example and doc of plc funcs and variables for ext sync.

### DIFF
--- a/examples/mcu1021_coupler_simplegear/cfg/linear_1.ax
+++ b/examples/mcu1021_coupler_simplegear/cfg/linear_1.ax
@@ -1,0 +1,82 @@
+#General
+epicsEnvSet("ECMC_MOTOR_NAME",            "Axis1")
+epicsEnvSet("ECMC_R",                     "Axis1-")
+epicsEnvSet("ECMC_AXIS_NO",               "1")
+epicsEnvSet("ECMC_DESC",                  "MCU1021 Lower Axis (1)")
+epicsEnvSet("ECMC_EGU",                   "mm")                        # Motor Record Unit
+epicsEnvSet("ECMC_PREC",                  "3")                         # Motor Record Precision
+epicsEnvSet("ECMC_AXISCONFIG",            "")                          # Extra parameters to driver
+epicsEnvSet("ECMC_EC_AXIS_HEALTH",        "")                          # Entry for axis health output (example: ec0.s1.BO_1.0)
+epicsEnvSet("ECMC_MOD_RANGE" ,            "0")                        # Modulo range (traj setpoints and encoder values will be in range 0..ECMC_MOD_RANGE)
+epicsEnvSet("ECMC_MOD_TYPE",              "0")                        # For positioning and MOD_RANGE>0: 0 = Normal, 1 = Always Fwd, 2 = Always Bwd, 3 = Closest Distance
+
+#Encoder
+epicsEnvSet("ECMC_ENC_SCALE_NUM"          "-60")
+epicsEnvSet("ECMC_ENC_SCALE_DENOM"        "2000")
+epicsEnvSet("ECMC_ENC_TYPE"               "0")                        # Type: 0=Incremental, 1=Absolute
+epicsEnvSet("ECMC_ENC_BITS"               "16")                       # Total bit count of encoder raw data
+epicsEnvSet("ECMC_ENC_ABS_BITS",          "0")                        # Absolute bit count (for absolute encoders) always least significant part of ECMC_ENC_BITS
+epicsEnvSet("ECMC_ENC_ABS_OFFSET"         "0")                        # Encoder offset in eng units (for absolute encoders)
+epicsEnvSet("ECMC_EC_ENC_ACTPOS",         "ec0.s3.POSITION")           # Ethercat entry for actual position input (encoder)
+
+#Drive
+epicsEnvSet("ECMC_DRV_TYPE"               "0")                         # Stepper: 0. DS402: 1 (DS402 = servos and advanced stepper drives)
+epicsEnvSet("ECMC_DRV_SCALE_NUM"          "600.0")                     # Fastest speed in engineering units
+epicsEnvSet("ECMC_DRV_SCALE_DENOM"        "32768.0")                   # I/O range for ECMC_EC_ALIAS_DRV_VELO_SET
+epicsEnvSet("ECMC_EC_DRV_CONTROL",        "ec0.s8.STM_CONTROL.0")      # Ethercat entry for control word or bit output
+epicsEnvSet("ECMC_EC_DRV_STATUS",         "ec0.s8.STM_STATUS.1")       # Ethercat entry for status word or bit input
+epicsEnvSet("ECMC_EC_DRV_VELOCITY",       "ec0.s8.VELOCITY_SETPOINT")  # Ethercat entry for velocity setpoint output
+epicsEnvSet("ECMC_EC_DRV_REDUCE_TORQUE",  "ec0.s8.STM_CONTROL.2")      # Ethercat entry for reduce torque output
+epicsEnvSet("ECMC_EC_DRV_BRAKE",          "")                          # Ethercat entry for brake output
+epicsEnvSet("ECMC_DRV_BRAKE_OPEN_DLY_TIME",    "0")                    # Brake timing parameter in cycles (default 1kHz)
+epicsEnvSet("ECMC_DRV_BRAKE_CLOSE_AHEAD_TIME", "0")                    # Brake timing parameter in cycles (default 1kHz)
+
+
+#Trajectory
+epicsEnvSet("ECMC_VELO",                  "10.0")
+epicsEnvSet("ECMC_JOG_VEL",               "5")
+epicsEnvSet("ECMC_JAR",                   "0.0")                       # JAR defaults to VELO/ACCL
+epicsEnvSet("ECMC_ACCL",                  "0.1")
+epicsEnvSet("ECMC_EMERG_DECEL",           "${ECMC_ACCL}")              # Emergency deceleration
+
+#Homing
+epicsEnvSet("ECMC_HOME_PROC",             "3")
+epicsEnvSet("ECMC_HOME_POS",              "0.0")
+epicsEnvSet("ECMC_HOME_VEL_TO",           "5")
+epicsEnvSet("ECMC_HOME_VEL_FRM",          "4")
+epicsEnvSet("ECMC_HOME_ACC",              "21")
+epicsEnvSet("ECMC_HOME_DEC",              "100")
+
+#Controller
+epicsEnvSet("ECMC_CNTRL_KP",              "15.0")
+epicsEnvSet("ECMC_CNTRL_KI",              "0.02")
+epicsEnvSet("ECMC_CNTRL_KD",              "0.0")
+epicsEnvSet("ECMC_CNTRL_KFF",             "1.0")
+
+#Monitoring
+# Switches
+epicsEnvSet("ECMC_EC_MON_LOWLIM",         "ec0.s1.BI_2.0")           #  Ethercat entry for low limit switch input
+epicsEnvSet("ECMC_EC_MON_HIGHLIM",        "ec0.s1.BI_1.0")           #  Ethercat entry for high limit switch inpuit
+epicsEnvSet("ECMC_EC_MON_HOME_SWITCH",    "ec0.s1.BI_3.0")           #  Ethercat entry for home switch input
+epicsEnvSet("ECMC_EC_MON_EXT_INTERLOCK",  "ec0.s1.ONE.0")               #  Ethercat entry for external interlock input
+
+# Softlimits (disable with 0,0,0)
+epicsEnvSet("ECMC_SOFT_LOW_LIM",          "-20")
+epicsEnvSet("ECMC_SOFT_HIGH_LIM",         "130")
+epicsEnvSet("ECMC_DXLM_ENABLE",           "1")
+
+# Position lag
+epicsEnvSet("ECMC_MON_LAG_MON_TOL",       "1.0")
+epicsEnvSet("ECMC_MON_LAG_MON_TIME",      "10")
+epicsEnvSet("ECMC_MON_LAG_MON_ENA",       "1")
+
+# At target
+epicsEnvSet("ECMC_MON_AT_TARGET_TOL",     "0.1")
+epicsEnvSet("ECMC_MON_AT_TARGET_TIME",     "100")
+epicsEnvSet("ECMC_MON_AT_TARGET_ENA",     "1")
+
+# Velocity
+epicsEnvSet("ECMC_MON_VELO_MAX",          "100.0")
+epicsEnvSet("ECMC_MON_VELO_MAX_TRAJ_TIME","100")
+epicsEnvSet("ECMC_MON_VELO_MAX_DRV_TIME", "200")
+epicsEnvSet("ECMC_MON_VELO_MAX_ENA",      "1")

--- a/examples/mcu1021_coupler_simplegear/cfg/linear_2.ax
+++ b/examples/mcu1021_coupler_simplegear/cfg/linear_2.ax
@@ -1,0 +1,81 @@
+#General
+epicsEnvSet("ECMC_MOTOR_NAME",            "Axis2")
+epicsEnvSet("ECMC_R",                     "Axis2-")
+epicsEnvSet("ECMC_AXIS_NO",               "2")
+epicsEnvSet("ECMC_DESC",                  "MCU1021 Upper Axis (2)")
+epicsEnvSet("ECMC_EGU",                   "mm")                       # Motor Record Unit
+epicsEnvSet("ECMC_PREC",                  "3")                        # Motor Record Precision
+epicsEnvSet("ECMC_AXISCONFIG",            "")                         # Extra parameters to driver
+epicsEnvSet("ECMC_EC_AXIS_HEALTH",        "")                         # Entry for axis health output (example: ec0.s1.BO_1.0)
+epicsEnvSet("ECMC_MOD_RANGE" ,            "0")                        # Modulo range (traj setpoints and encoder values will be in range 0..ECMC_MOD_RANGE)
+epicsEnvSet("ECMC_MOD_TYPE",              "0")                        # For positioning and MOD_RANGE>0: 0 = Normal, 1 = Always Fwd, 2 = Always Bwd, 3 = Closest Distance
+
+#Encoder
+epicsEnvSet("ECMC_ENC_SCALE_NUM"          "60")
+epicsEnvSet("ECMC_ENC_SCALE_DENOM"        "2000")
+epicsEnvSet("ECMC_ENC_TYPE"               "0")                        # Type: 0=Incremental, 1=Absolute
+epicsEnvSet("ECMC_ENC_BITS"               "16")                       # Total bit count of encoder raw data
+epicsEnvSet("ECMC_ENC_ABS_BITS",          "0")                        # Absolute bit count (for absolute encoders) always least significant part of ECMC_ENC_BITS
+epicsEnvSet("ECMC_ENC_ABS_OFFSET"         "0")                        # Encoder offset in eng units (for absolute encoders)
+epicsEnvSet("ECMC_EC_ENC_ACTPOS",         "ec0.s4.POSITION")          # Ethercat entry for actual position input (encoder)
+
+#Drive
+epicsEnvSet("ECMC_DRV_TYPE"               "0")                        # Stepper: 0. DS402: 1 (DS402 = servos and advanced stepper drives)
+epicsEnvSet("ECMC_DRV_SCALE_NUM"          "-600.0")                   # Fastest speed in engineering units
+epicsEnvSet("ECMC_DRV_SCALE_DENOM"        "32768.0")                  # I/O range for ECMC_EC_ALIAS_DRV_VELO_SET
+epicsEnvSet("ECMC_EC_DRV_CONTROL",        "ec0.s9.STM_CONTROL.0")     # Ethercat entry for control word or bit output
+epicsEnvSet("ECMC_EC_DRV_STATUS",         "ec0.s9.STM_STATUS.1")      # Ethercat entry for status word or bit input
+epicsEnvSet("ECMC_EC_DRV_VELOCITY",       "ec0.s9.VELOCITY_SETPOINT") # Ethercat entry for velocity setpoint output
+epicsEnvSet("ECMC_EC_DRV_REDUCE_TORQUE",  "ec0.s9.STM_CONTROL.2")     # Ethercat entry for reduce torque output
+epicsEnvSet("ECMC_EC_DRV_BRAKE",          "")                         # Ethercat entry for brake output
+epicsEnvSet("ECMC_DRV_BRAKE_OPEN_DLY_TIME",    "0")                   # Brake timing parameter in cycles (default 1kHz)
+epicsEnvSet("ECMC_DRV_BRAKE_CLOSE_AHEAD_TIME", "0")                   # Brake timing parameter in cycles (default 1kHz)
+
+#Trajectory
+epicsEnvSet("ECMC_VELO",                  "10.0")
+epicsEnvSet("ECMC_JOG_VEL",               "5")
+epicsEnvSet("ECMC_JAR",                   "0.0")                      # JAR defaults to VELO/ACCL
+epicsEnvSet("ECMC_ACCL",                  "0.1")
+epicsEnvSet("ECMC_EMERG_DECEL",           "${ECMC_ACCL}")             # Emergency deceleration
+
+#Homing
+epicsEnvSet("ECMC_HOME_PROC",             "3")
+epicsEnvSet("ECMC_HOME_POS",              "0.0")
+epicsEnvSet("ECMC_HOME_VEL_TO",           "5")
+epicsEnvSet("ECMC_HOME_VEL_FRM",          "4")
+epicsEnvSet("ECMC_HOME_ACC",              "21")
+epicsEnvSet("ECMC_HOME_DEC",              "100")
+
+#Controller
+epicsEnvSet("ECMC_CNTRL_KP",              "15.0")
+epicsEnvSet("ECMC_CNTRL_KI",              "0.02")
+epicsEnvSet("ECMC_CNTRL_KD",              "0.0")
+epicsEnvSet("ECMC_CNTRL_KFF",             "1.0")
+
+#Monitoring
+# Switches
+epicsEnvSet("ECMC_EC_MON_LOWLIM",         "ec0.s1.BI_6.0")           #  Ethercat entry for low limit switch input
+epicsEnvSet("ECMC_EC_MON_HIGHLIM",        "ec0.s1.BI_5.0")           #  Ethercat entry for high limit switch inpuit
+epicsEnvSet("ECMC_EC_MON_HOME_SWITCH",    "ec0.s1.BI_7.0")           #  Ethercat entry for home switch input
+epicsEnvSet("ECMC_EC_MON_EXT_INTERLOCK",  "ec0.s0.ONE.0")              #  Ethercat entry for external interlock input
+
+# Softlimits (disable with 0,0)
+epicsEnvSet("ECMC_SOFT_LOW_LIM",          "-130")
+epicsEnvSet("ECMC_SOFT_HIGH_LIM",         "20")
+epicsEnvSet("ECMC_DXLM_ENABLE",           "1")
+
+# Position lag
+epicsEnvSet("ECMC_MON_LAG_MON_TOL",       "1.0")
+epicsEnvSet("ECMC_MON_LAG_MON_TIME",      "10")
+epicsEnvSet("ECMC_MON_LAG_MON_ENA",       "1")
+
+# At target
+epicsEnvSet("ECMC_MON_AT_TARGET_TOL",     "0.1")
+epicsEnvSet("ECMC_MON_AT_TARGET_TIME",     "100")
+epicsEnvSet("ECMC_MON_AT_TARGET_ENA",     "1")
+
+# Velocity
+epicsEnvSet("ECMC_MON_VELO_MAX",          "100.0")
+epicsEnvSet("ECMC_MON_VELO_MAX_TRAJ_TIME","100")
+epicsEnvSet("ECMC_MON_VELO_MAX_DRV_TIME", "200")
+epicsEnvSet("ECMC_MON_VELO_MAX_ENA",      "1")

--- a/examples/mcu1021_coupler_simplegear/cfg/linear_2.sax
+++ b/examples/mcu1021_coupler_simplegear/cfg/linear_2.sax
@@ -1,0 +1,25 @@
+############# Encoder
+epicsEnvSet("ECMC_ENC_SOURCE",                 "0")      # 0 Internal (from hardware), 1 from PLC
+epicsEnvSet("ECMC_ENC_VELO_FILT_ENABLE",       "1")      # Enable velocity filter
+epicsEnvSet("ECMC_ENC_VELO_FILT_SIZE",         "20")     # Encoder velocity Low pass filter size
+
+############# Trajectory
+epicsEnvSet("ECMC_TRAJ_SOURCE",                "1")      # 0 Internal (from hardware), 1 from PLC
+epicsEnvSet("ECMC_TRAJ_VELO_FILT_ENABLE",      "1")      # Enable velocity filter
+epicsEnvSet("ECMC_TRAJ_VELO_FILT_SIZE",        "20")     # Trajectory velocity Low pass filter size
+
+############# Commands 
+epicsEnvSet("ECMC_CMD_FRM_OTHER_PLC_ENABLE",   "1")      # Allow commands from PLC
+epicsEnvSet("ECMC_CMD_AXIS_PLC_ENABLE",        "1")      # Enable Axis PLC
+# Each line below is appended to one single expression/source. 
+# Executed in sync with axis (before)
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_1",           "if(ax2.traj.source){ax2.drv.enable:=ax1.drv.enable}|")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_2",           "ax2.traj.setpos:=ax1.traj.setpos*0.5|")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_3",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_4",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_5",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_6",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_7",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_8",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_9",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_10",          "")

--- a/examples/mcu1021_coupler_simplegear/cfg/linear_3.sax
+++ b/examples/mcu1021_coupler_simplegear/cfg/linear_3.sax
@@ -1,0 +1,25 @@
+############# Encoder
+epicsEnvSet("ECMC_ENC_SOURCE",                 "1")       # 0 Internal (from hardware), 1 from PLC
+epicsEnvSet("ECMC_ENC_VELO_FILT_ENABLE",       "1")       # Enable velocity filter
+epicsEnvSet("ECMC_ENC_VELO_FILT_SIZE",         "10")      # Encoder velocity Low pass filter size
+
+############# Trajectory
+epicsEnvSet("ECMC_TRAJ_SOURCE",                "0")       # 0 Internal (from hardware), 1 from PLC
+epicsEnvSet("ECMC_TRAJ_VELO_FILT_ENABLE",      "1")       # Enable velocity filter
+epicsEnvSet("ECMC_TRAJ_VELO_FILT_SIZE",        "10")      # Trajectory velocity Low pass filter size
+
+############# Commands 
+epicsEnvSet("ECMC_CMD_FRM_OTHER_PLC_ENABLE",  "1")        # Allow commands from PLC
+epicsEnvSet("ECMC_CMD_AXIS_PLC_ENABLE",       "1")        # Enable Axis PLC
+# Each line below is appended to one single expression/source. 
+# Executed in sync with axis (before)
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_1",           "ax3.enc.actpos:=ax2.enc.actpos-ax1.enc.actpos|")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_2",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_3",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_4",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_5",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_6",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_7",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_8",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_9",           "")
+epicsEnvSet("ECMC_AXIS_EXPR_LINE_10",          "")

--- a/examples/mcu1021_coupler_simplegear/cfg/linear_3.vax
+++ b/examples/mcu1021_coupler_simplegear/cfg/linear_3.vax
@@ -1,0 +1,63 @@
+#General
+epicsEnvSet("ECMC_MOTOR_NAME",            "Axis3")
+epicsEnvSet("ECMC_R",                     "Axis3-")
+epicsEnvSet("ECMC_AXIS_NO",               "3")
+epicsEnvSet("ECMC_DESC",                  "MCU1021 Gap (2)")
+epicsEnvSet("ECMC_EGU",                   "mm")                       # Motor Record Unit
+epicsEnvSet("ECMC_PREC",                  "3")                        # Motor Record Precision
+epicsEnvSet("ECMC_AXISCONFIG",            "")                         # Extra parameters to driver
+epicsEnvSet("ECMC_EC_AXIS_HEALTH",        "")                         # Entry for axis health output (example: ec0.s1.BO_1.0)
+epicsEnvSet("ECMC_MOD_RANGE" ,            "0")                        # Modulo range (traj setpoints and encoder values will be in range 0..ECMC_MOD_RANGE)
+epicsEnvSet("ECMC_MOD_TYPE",              "0")                        # For positioning and MOD_RANGE>0: 0 = Normal, 1 = Always Fwd, 2 = Always Bwd, 3 = Closest Distance
+
+#Encoder
+epicsEnvSet("ECMC_ENC_SCALE_NUM"          "1")
+epicsEnvSet("ECMC_ENC_SCALE_DENOM"        "1")
+epicsEnvSet("ECMC_ENC_TYPE"               "1")                        # Type: 0=Incremental, 1=Absolute
+epicsEnvSet("ECMC_ENC_BITS"               "0")                        # Total bit count of encoder raw data
+epicsEnvSet("ECMC_ENC_ABS_BITS",          "0")                        # Absolute bit count (for absolute encoders) always least significant part of ECMC_ENC_BITS
+epicsEnvSet("ECMC_ENC_ABS_OFFSET"         "0")                        # Encoder offset in eng units (for absolute encoders)
+epicsEnvSet("ECMC_EC_ENC_ACTPOS",         "ec0.s0.ZERO")              # Ethercat entry for actual position input (encoder)
+
+#Trajectory
+epicsEnvSet("ECMC_VELO",                  "5.0")
+epicsEnvSet("ECMC_JOG_VEL",               "5")
+epicsEnvSet("ECMC_JAR",                   "0.0")                      # JAR defaults to VELO/ACCL
+epicsEnvSet("ECMC_ACCL",                  "0.1")
+epicsEnvSet("ECMC_EMERG_DECEL",           "${ECMC_ACCL}")             # Emergency deceleration
+
+#Homing
+epicsEnvSet("ECMC_HOME_PROC",             "3")
+epicsEnvSet("ECMC_HOME_POS",              "0")
+epicsEnvSet("ECMC_HOME_VEL_TO",           "5")
+epicsEnvSet("ECMC_HOME_VEL_FRM",          "4")
+epicsEnvSet("ECMC_HOME_ACC",              "21")
+epicsEnvSet("ECMC_HOME_DEC",              "100")
+
+#Monitoring
+# Switches
+epicsEnvSet("ECMC_EC_MON_LOWLIM",         "ec0.s1.ONE.0")            #  Ethercat entry for low limit switch input
+epicsEnvSet("ECMC_EC_MON_HIGHLIM",        "ec0.s1.ONE.0")            #  Ethercat entry for high limit switch inpuit
+epicsEnvSet("ECMC_EC_MON_HOME_SWITCH",    "ec0.s1.ONE.0")            #  Ethercat entry for home switch input
+epicsEnvSet("ECMC_EC_MON_EXT_INTERLOCK",  "ec0.s1.ONE.0")            #  Ethercat entry for external interlock input
+
+# Softlimits (disable with 0,0,0)
+epicsEnvSet("ECMC_SOFT_LOW_LIM",          "0")
+epicsEnvSet("ECMC_SOFT_HIGH_LIM",         "0")
+epicsEnvSet("ECMC_DXLM_ENABLE",           "0")
+
+# Position lag
+epicsEnvSet("ECMC_MON_LAG_MON_TOL",       "0.5")
+epicsEnvSet("ECMC_MON_LAG_MON_TIME",      "100")
+epicsEnvSet("ECMC_MON_LAG_MON_ENA",       "0")
+
+# At target
+epicsEnvSet("ECMC_MON_AT_TARGET_TOL",     "0.3")
+epicsEnvSet("ECMC_MON_AT_TARGET_TIME",    "100")
+epicsEnvSet("ECMC_MON_AT_TARGET_ENA",     "1")
+
+# Velocity
+epicsEnvSet("ECMC_MON_VELO_MAX",          "200.0")
+epicsEnvSet("ECMC_MON_VELO_MAX_TRAJ_TIME","100")
+epicsEnvSet("ECMC_MON_VELO_MAX_DRV_TIME", "200")
+epicsEnvSet("ECMC_MON_VELO_MAX_ENA",      "1")

--- a/examples/mcu1021_coupler_simplegear/mcu1021_coupler.script
+++ b/examples/mcu1021_coupler_simplegear/mcu1021_coupler.script
@@ -1,0 +1,70 @@
+##############################################################################
+## Example config ESS crate of type MCU1025
+## Axis 1 is configuered as master and axis 2 will slave/follow with a gear ratio
+
+##############################################################################
+## Initiation:
+epicsEnvSet("IOC" ,"$(IOC="IOC_TEST")")
+epicsEnvSet("ECMCCFG_INIT" ,"")  #Only run startup once (auto at PSI, need call at ESS), variable set to "#" in startup.cmd
+epicsEnvSet("SCRIPTEXEC" ,"$(SCRIPTEXEC="iocshLoad")")
+
+require ecmccfg develop
+
+# Epics Motor record driver that will be used:
+epicsEnvShow(ECMC_MR_MODULE)
+
+# run module startup.cmd (only needed at ESS  PSI auto call at require)
+$(ECMCCFG_INIT)$(SCRIPTEXEC) ${ecmccfg_DIR}startup.cmd, "IOC=$(IOC),ECMC_VER=develop"
+
+##############################################################################
+## Configure hardware:
+
+ecmcFileExist($(ecmccfg_DIR)ecmcMCU1021_coupler.cmd,1)
+$(SCRIPTEXEC) $(ecmccfg_DIR)ecmcMCU1021_coupler.cmd
+
+#Apply hardware configuration
+ecmcConfigOrDie "Cfg.EcApplyConfig(1)"
+
+
+# ADDITIONAL SETUP
+# Set all outputs to feed switches
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},BO_1,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},BO_2,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},BO_3,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},BO_4,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},BO_5,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},BO_6,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},BO_7,1)"
+ecmcConfigOrDie "Cfg.WriteEcEntryIDString(${ECMC_EC_SLAVE_NUM_DIG_OUT},BO_8,1)"
+# END of ADDITIONAL SETUP
+
+##############################################################################
+## AXIS 1
+#
+epicsEnvSet("DEV",      "$(IOC)")
+$(SCRIPTEXEC) ($(ecmccfg_DIR)configureAxis.cmd, CONFIG=./cfg/linear_1.ax)
+
+##############################################################################
+## AXIS 2
+#
+epicsEnvSet("DEV",      "$(IOC)")
+$(SCRIPTEXEC) ($(ecmccfg_DIR)configureAxis.cmd, CONFIG=./cfg/linear_2.ax)
+$(SCRIPTEXEC) ($(ecmccfg_DIR)applyAxisSynchronization.cmd, CONFIG=./cfg/linear_2.sax)
+
+##############################################################################
+## PLC 0: Test mc_move_gear_in()
+$(SCRIPTEXEC) $(ecmccfg_DIR)loadPLCFile.cmd, "PLC_ID=0, SAMPLE_RATE_MS=1000,FILE=./plc/mc_gear_test.plc, PLC_MACROS='DBG=,PLC_ID=0,AX_ID=2'")
+#dbLoadRecords("ecmcPlcAnalog.db","P=$(IOC):,PORT=MC_CPU1,ASYN_NAME=plcs.plc0.static.test,REC_NAME=-Test,TSE=0,T_SMP_MS=1000")
+
+##############################################################################
+############# Configure diagnostics:
+
+ecmcConfigOrDie "Cfg.EcSetDiagnostics(1)"
+ecmcConfigOrDie "Cfg.EcEnablePrintouts(0)"
+ecmcConfigOrDie "Cfg.EcSetDomainFailedCyclesLimit(100)"
+ecmcConfigOrDie "Cfg.SetDiagAxisIndex(1)"
+ecmcConfigOrDie "Cfg.SetDiagAxisFreq(2)"
+ecmcConfigOrDie "Cfg.SetDiagAxisEnable(0)"
+
+# go active
+$(SCRIPTEXEC) ($(ecmccfg_DIR)setAppMode.cmd)

--- a/examples/mcu1021_coupler_simplegear/plc/mc_gear_test.plc
+++ b/examples/mcu1021_coupler_simplegear/plc/mc_gear_test.plc
@@ -1,0 +1,53 @@
+###############################################################################
+# inline double mc_move_gear_in(double axIndex,double execute, double vel, double acc, double dec)
+###############################################################################
+
+static.counter:=static.counter+1;
+
+# Init
+if(plc${PLC_ID=0}.firstscan){
+  println('Init!!!!!!!!!');
+  ax${AX_ID=0}.traj.source:= 0;  
+  #ax${AX_ID=0}.plc.enable:=1;
+  #ax${AX_ID=0}.allowplccmd:=1;
+  return[];
+};
+ 
+# Power on
+#if(static.state=1) {
+#  mc_power(${AX_ID=0},1);
+#  static.state:=2;
+#  return [];
+#};
+
+println('-------------------------------------------');
+println('Ext setpos ax1:',ax1.traj.extsetpos);
+println('Setpos ax1:    ',ax1.traj.setpos);
+println('Ext setpos ax2:',ax2.traj.extsetpos);
+println('Setpos ax2:    ',ax2.traj.setpos);
+if(static.counter = 2) {
+ println('move gear in 0');
+};
+
+if(static.counter>2 and static.counter<9) {
+  mc_move_ext_pos(${AX_ID=0},0, 10, 1, 1);
+};
+
+if(static.counter = 20) {
+ println('move gear in 1');
+};
+
+# wait  20 seconds then issue 
+if(static.counter>20) {
+  #mc_power(1,1);
+  mc_power(${AX_ID=0},1);
+  #if(ax${AX_ID=0}.drv.enabled) {
+  #  mc_move_abs(${AX_ID=0},1,ax${AX_ID=0}.traj.extsetpos, 10, 1, 1);
+  #};
+
+  if(ax${AX_ID=0}.drv.enabled) {
+    mc_move_ext_pos(${AX_ID=0},1, 10, 1, 1);
+  };
+};
+
+static.counterOld:=static.counter;

--- a/examples/test/plc/ReadMe.md
+++ b/examples/test/plc/ReadMe.md
@@ -87,26 +87,30 @@ Below the ECMC specific accessible variables and functions are listed:
 4.  ax<id>.error                 error                            (ro)
 5.  ax<id>.allowplccmd           Allow writes to axis from PLC    (rw)
 6.  ax<id>.enc.actpos            actual position                  (ro)
-7.  ax<id>.enc.actvel            actual velocity                  (ro)
-8.  ax<id>.enc.rawpos            actual raw position              (ro)
-9.  ax<id>.enc.source            internal source or expressions   (rw)
+7.  ax<id>.enc.extactpos         actual position from plc sync.
+                                 expression                       (ro)
+8.  ax<id>.enc.actvel            actual velocity                  (ro)
+9.  ax<id>.enc.rawpos            actual raw position              (ro)
+10.  ax<id>.enc.source            internal source or expressions   (rw)
                                  source = 0: internal encoder
                                  source > 0: actual pos from expr
-10. ax<id>.enc.homed             encoder homed                    (rw)
-11. ax<id>.enc.homepos           homing position                  (rw)
-12. ax<id>.traj.setpos           curent trajectory setpoint       (rw)
-13. ax<id>.traj.targetpos        target position                  (rw)
-14. ax<id>.traj.targetvel        target velocity setpoint         (rw)
-15. ax<id>.traj.targetacc        target acceleration setpoint     (rw)
-16. ax<id>.traj.targetdec        target deceleration setpoint     (rw)
-17. ax<id>.traj.setvel           current velocity setpoint        (ro)
-18. ax<id>.traj.setvelffraw      feed forward raw velocity        (ro)
-19. ax<id>.traj.command          command                          (rw)
+11. ax<id>.enc.homed             encoder homed                    (rw)
+12. ax<id>.enc.homepos           homing position                  (rw)
+13. ax<id>.traj.setpos           curent trajectory setpoint       (rw)
+14. ax<id>.traj.targetpos        target position                  (rw)
+15. ax<id>.traj.extsetpos        current trajecrory setpoint from
+                                 plc sync. expression             (ro) 
+16. ax<id>.traj.targetvel        target velocity setpoint         (rw)
+17. ax<id>.traj.targetacc        target acceleration setpoint     (rw)
+18. ax<id>.traj.targetdec        target deceleration setpoint     (rw)
+19. ax<id>.traj.setvel           current velocity setpoint        (ro)
+20. ax<id>.traj.setvelffraw      feed forward raw velocity        (ro)
+21. ax<id>.traj.command          command                          (rw)
                                  command=1: move velocity  
                                  command=2: move rel. pos
                                  command=3: move abs. pos
                                  command=10: homing
-20. ax<id>.traj.cmddata          cmddat. Homing procedure
+22. ax<id>.traj.cmddata          cmddat. Homing procedure
                                  only valid if ax<id>.traj.command=10
                                  cmddata=1 : ref low limit
                                  cmddata=2 : ref high limit
@@ -127,40 +131,40 @@ Below the ECMC specific accessible variables and functions are listed:
                                               (via high limit).
                                               ref at abs bits.
                                               over/under-flow..
-21. ax<id>.traj.source           internal source or expressions   (rw)
+23. ax<id>.traj.source           internal source or expressions   (rw)
                                  source = 0: internal traj
                                  source > 0: setpoints from expr
-22. ax<id>.traj.execute          execute motion command           (rw)
-23. ax<id>.traj.busy             axis busy                        (ro)
-24. ax<id>.traj.dir              axis setpoint direction          (ro)
+24. ax<id>.traj.execute          execute motion command           (rw)
+25. ax<id>.traj.busy             axis busy                        (ro)
+26. ax<id>.traj.dir              axis setpoint direction          (ro)
                                  ax<id>.traj.dir>0: forward
                                  ax<id>.traj.dir<0: backward
                                  ax<id>.traj.dir=0: standstill
-25. ax<id>.cntrl.error           actual controller error          (ro)
-26. ax<id>.cntrl.poserror        actual position error            (ro)
-27. ax<id>.cntrl.output          actual controller output         (ro)
-28. ax<id>.drv.setvelraw         actual raw velocity setpoint     (ro)
-29. ax<id>.drv.enable            enable drive command             (rw)
-30. ax<id>.drv.enabled           drive enabled                    (ro)
-31. ax<id>.seq.state             sequence state (homing)          (ro)
-32. ax<id>.mon.ilock             motion interlock (both dir)      (rw)
+27. ax<id>.cntrl.error           actual controller error          (ro)
+28. ax<id>.cntrl.poserror        actual position error            (ro)
+29. ax<id>.cntrl.output          actual controller output         (ro)
+30. ax<id>.drv.setvelraw         actual raw velocity setpoint     (ro)
+31. ax<id>.drv.enable            enable drive command             (rw)
+32. ax<id>.drv.enabled           drive enabled                    (ro)
+33. ax<id>.seq.state             sequence state (homing)          (ro)
+34. ax<id>.mon.ilock             motion interlock (both dir)      (rw)
                                  ax<id>.mon.ilock=1: motion allowed
                                  ax<id>.mon.ilock=0: motion not allowed        
-33. ax<id>.mon.ilockbwd          motion interlock bwd dir         (rw)
+35. ax<id>.mon.ilockbwd          motion interlock bwd dir         (rw)
                                  ax<id>.mon.ilockbwd=1: motion allowed
                                  ax<id>.mon.ilockbwd=0: motion not allowed        
-34. ax<id>.mon.ilockfwd          motion interlock fwd dir         (rw)
+36. ax<id>.mon.ilockfwd          motion interlock fwd dir         (rw)
                                  ax<id>.mon.ilockfwd=1: motion allowed
                                  ax<id>.mon.ilockfwd=0: motion not allowed        
-35. ax<id>.mon.attarget          axis at taget                    (ro)
-36. ax<id>.mon.lowlim            low limit switch                 (ro)
-37. ax<id>.mon.highlim           high limit switch                (ro)
-38. ax<id>.mon.homesensor        home sensor                      (ro)
-39. ax<id>.mon.lowsoftlim        low soft limit                   (rw)
-40. ax<id>.mon.highsoftlim       high soft limit                  (rw)
-41. ax<id>.mon.lowsoftlimenable  low soft limit enable            (rw)
-42. ax<id>.mon.highsoftlimenable high soft limit enable           (rw)
-43. ax<id>.blockcom              Enables/disables "set" commands  (rw)
+37. ax<id>.mon.attarget          axis at taget                    (ro)
+38. ax<id>.mon.lowlim            low limit switch                 (ro)
+39. ax<id>.mon.highlim           high limit switch                (ro)
+40. ax<id>.mon.homesensor        home sensor                      (ro)
+41. ax<id>.mon.lowsoftlim        low soft limit                   (rw)
+42. ax<id>.mon.highsoftlim       high soft limit                  (rw)
+43. ax<id>.mon.lowsoftlimenable  low soft limit enable            (rw)
+44. ax<id>.mon.highsoftlimenable high soft limit enable           (rw)
+45. ax<id>.blockcom              Enables/disables "set" commands  (rw)
                                  via command parser (ascii commands)
                                  Statuses can still be read.
                                  Exceptions ("set"-commands) that 
@@ -409,7 +413,21 @@ Below the ECMC specific accessible variables and functions are listed:
    Motion is triggerd with a positive edge on <execute> input.
    returns 0 if success or error code.
 
-3. retvalue = mc_move_vel(
+3. retvalue = mc_move_ext_pos(
+                        <axIndex>,       : Axis index
+                        <execute>,       : Trigger
+                        <vel>,           : Target velocity
+                        <acc>,           : Acceleration
+                        <dec>            : Deceleration
+                        );
+   Move to current external plc position. Functions intended use is to 
+   move to the start position for syncronized axes. This command is exactly 
+   the same as issueing "mc_move_pos()" with the target postion ax<id>.traj.extsetpos.
+   Motion is triggerd with a positive edge on <execute> input.
+   returns 0 if success or error code.
+
+
+4. retvalue = mc_move_vel(
                         <axIndex>,       : Axis index
                         <execute>,       : Trigger
                         <vel>,           : Target velocity
@@ -420,7 +438,7 @@ Below the ECMC specific accessible variables and functions are listed:
    Motion is triggerd with a positive edge on <execute> input.
    returns 0 if success or error code.
 
-4. retvalue = mc_home(
+5. retvalue = mc_home(
                         <axIndex>,       : Axis index
                         <execute>,       : Trigger
                         <seqId>,         : Motion sequence
@@ -431,7 +449,7 @@ Below the ECMC specific accessible variables and functions are listed:
    Motion is triggerd with a positive edge on <execute> input.
    returns 0 if success or error code.
 
-5. retvalue = mc_halt(
+6. retvalue = mc_halt(
                         <axIndex>,       : Axis index
                         <execute>,       : Trigger
                         );
@@ -439,7 +457,7 @@ Below the ECMC specific accessible variables and functions are listed:
    Motion is triggerd with a positive edge on <execute> input.
    returns 0 if success or error code.
 
-6. retvalue = mc_power(
+7. retvalue = mc_power(
                         <axIndex>,       : Axis index
                         <enable>,        : Enable power
                         );
@@ -447,28 +465,28 @@ Below the ECMC specific accessible variables and functions are listed:
    Motion is triggerd with a positive edge on <execute> input.
    returns 0 if success or error code.
 
-7. retvalue = mc_get_busy(
+8. retvalue = mc_get_busy(
                         <axIndex>,       : Axis index#                           
                         );
    Check if axis is busy.
    returns busy state of axis (1 if busy and 0 if not busy).
 
-8. retvalue = mc_get_homed(
+9. retvalue = mc_get_homed(
                         <axIndex>,       : Axis index#                           
                         );
    Check if axis is homed.
    returns state of homed flag of axis (1 if homed and 0 if not homed).
 
-9. retvalue = mc_get_err();
+10. retvalue = mc_get_err();
    Returns error code for last lib call.
 
-10. retvalue = mc_reset(<axIndex>);
+11. retvalue = mc_reset(<axIndex>);
    Resets error of motion axis.
 
-11. retvalue = mc_get_axis_err(<axIndex>);
+12. retvalue = mc_get_axis_err(<axIndex>);
    Returns motion axis error code.
 
-12. retvalue = mc_set_enable_motion_funcs(
+13. retvalue = mc_set_enable_motion_funcs(
                         <axIndex>,         : Axis index
                         <enablePos>,       : Enable positioning
                         <enableVelo>,      : Enable const velo

--- a/examples/test/plc/plcSyntaxHelp.plc
+++ b/examples/test/plc/plcSyntaxHelp.plc
@@ -75,26 +75,30 @@
 #   4.  ax<id>.error                 error                            (ro)
 #   5.  ax<id>.allowplccmd           Allow writes to axis from PLC    (rw)
 #   6.  ax<id>.enc.actpos            actual position                  (ro)
-#   7.  ax<id>.enc.actvel            actual velocity                  (ro)
-#   8.  ax<id>.enc.rawpos            actual raw position              (ro)
-#   9.  ax<id>.enc.source            internal source or expressions   (rw)
+#   7.  ax<id>.enc.extactpos         actual position from plc sync.
+#                                    expression                       (ro)
+#   8.  ax<id>.enc.actvel            actual velocity                  (ro)
+#   9.  ax<id>.enc.rawpos            actual raw position              (ro)
+#   10.  ax<id>.enc.source            internal source or expressions   (rw)
 #                                    source = 0: internal encoder
 #                                    source > 0: actual pos from expr
-#   10. ax<id>.enc.homed             encoder homed                    (rw)
-#   11. ax<id>.enc.homepos           homing position                  (rw)
-#   12. ax<id>.traj.setpos           curent trajectory setpoint       (rw)
-#   13. ax<id>.traj.targetpos        target position                  (rw)
-#   14. ax<id>.traj.targetvel        target velocity setpoint         (rw)
-#   15. ax<id>.traj.targetacc        target acceleration setpoint     (rw)
-#   16. ax<id>.traj.targetdec        target deceleration setpoint     (rw)
-#   17. ax<id>.traj.setvel           current velocity setpoint        (ro)
-#   18. ax<id>.traj.setvelffraw      feed forward raw velocity        (ro)
-#   19. ax<id>.traj.command          command                          (rw)
+#   11. ax<id>.enc.homed             encoder homed                    (rw)
+#   12. ax<id>.enc.homepos           homing position                  (rw)
+#   13. ax<id>.traj.setpos           curent trajectory setpoint       (rw)
+#   14. ax<id>.traj.extsetpos        current trajecrory setpoint from
+#                                    plc sync. expression             (ro) 
+#   15. ax<id>.traj.targetpos        target position                  (rw)
+#   16. ax<id>.traj.targetvel        target velocity setpoint         (rw)
+#   17. ax<id>.traj.targetacc        target acceleration setpoint     (rw)
+#   18. ax<id>.traj.targetdec        target deceleration setpoint     (rw)
+#   19. ax<id>.traj.setvel           current velocity setpoint        (ro)
+#   20. ax<id>.traj.setvelffraw      feed forward raw velocity        (ro)
+#   21. ax<id>.traj.command          command                          (rw)
 #                                    command=1: move velocity  
 #                                    command=2: move rel. pos
 #                                    command=3: move abs. pos
 #                                    command=10: homing
-#   20. ax<id>.traj.cmddata          cmddat. Homing procedure
+#   22. ax<id>.traj.cmddata          cmddat. Homing procedure
 #                                    only valid if ax<id>.traj.command=10
 #                                    cmddata=1 : ref low limit
 #                                    cmddata=2 : ref high limit
@@ -115,40 +119,40 @@
 #                                                 (via high limit).
 #                                                 ref at abs bits.
 #                                                 over/under-flow..
-#   21. ax<id>.traj.source           internal source or expressions   (rw)
+#   23. ax<id>.traj.source           internal source or expressions   (rw)
 #                                    source = 0: internal traj
 #                                    source > 0: setpoints from expr
-#   22. ax<id>.traj.execute          execute motion command           (rw)
-#   23. ax<id>.traj.busy             axis busy                        (ro)
-#   24. ax<id>.traj.dir              axis setpoint direction          (ro)
+#   24. ax<id>.traj.execute          execute motion command           (rw)
+#   25. ax<id>.traj.busy             axis busy                        (ro)
+#   26. ax<id>.traj.dir              axis setpoint direction          (ro)
 #                                    ax<id>.traj.dir>0: forward
 #                                    ax<id>.traj.dir<0: backward
 #                                    ax<id>.traj.dir=0: standstill
-#   25. ax<id>.cntrl.error           actual controller error          (ro)
-#   26. ax<id>.cntrl.poserror        actual position error            (ro)
-#   27. ax<id>.cntrl.output          actual controller output         (ro)
-#   28. ax<id>.drv.setvelraw         actual raw velocity setpoint     (ro)
-#   29. ax<id>.drv.enable            enable drive command             (rw)
-#   30. ax<id>.drv.enabled           drive enabled                    (ro)
-#   31. ax<id>.seq.state             sequence state (homing)          (ro)
-#   32. ax<id>.mon.ilock             motion interlock (both dir)      (rw)
+#   27. ax<id>.cntrl.error           actual controller error          (ro)
+#   28. ax<id>.cntrl.poserror        actual position error            (ro)
+#   29. ax<id>.cntrl.output          actual controller output         (ro)
+#   30. ax<id>.drv.setvelraw         actual raw velocity setpoint     (ro)
+#   31. ax<id>.drv.enable            enable drive command             (rw)
+#   32. ax<id>.drv.enabled           drive enabled                    (ro)
+#   33. ax<id>.seq.state             sequence state (homing)          (ro)
+#   34. ax<id>.mon.ilock             motion interlock (both dir)      (rw)
 #                                    ax<id>.mon.ilock=1: motion allowed
 #                                    ax<id>.mon.ilock=0: motion not allowed        
-#   33. ax<id>.mon.ilockbwd          motion interlock bwd dir         (rw)
+#   35. ax<id>.mon.ilockbwd          motion interlock bwd dir         (rw)
 #                                    ax<id>.mon.ilockbwd=1: motion allowed
 #                                    ax<id>.mon.ilockbwd=0: motion not allowed        
-#   34. ax<id>.mon.ilockfwd          motion interlock fwd dir         (rw)
+#   36. ax<id>.mon.ilockfwd          motion interlock fwd dir         (rw)
 #                                    ax<id>.mon.ilockfwd=1: motion allowed
 #                                    ax<id>.mon.ilockfwd=0: motion not allowed        
-#   35. ax<id>.mon.attarget          axis at taget                    (ro)
-#   36. ax<id>.mon.lowlim            low limit switch                 (ro)
-#   37. ax<id>.mon.highlim           high limit switch                (ro)
-#   38. ax<id>.mon.homesensor        home sensor                      (ro)
-#   39. ax<id>.mon.lowsoftlim        low soft limit                   (rw)
-#   40. ax<id>.mon.highsoftlim       high soft limit                  (rw)
-#   41. ax<id>.mon.lowsoftlimenable  low soft limit enable            (rw)
-#   42. ax<id>.mon.highsoftlimenable high soft limit enable           (rw)
-#   43. ax<id>.blockcom              Enables/disables "set" commands   (rw)
+#   37. ax<id>.mon.attarget          axis at taget                    (ro)
+#   38. ax<id>.mon.lowlim            low limit switch                 (ro)
+#   39. ax<id>.mon.highlim           high limit switch                (ro)
+#   40. ax<id>.mon.homesensor        home sensor                      (ro)
+#   41. ax<id>.mon.lowsoftlim        low soft limit                   (rw)
+#   42. ax<id>.mon.highsoftlim       high soft limit                  (rw)
+#   43. ax<id>.mon.lowsoftlimenable  low soft limit enable            (rw)
+#   44. ax<id>.mon.highsoftlimenable high soft limit enable           (rw)
+#   45. ax<id>.blockcom              Enables/disables "set" commands   (rw)
 #                                    via command parser (ascii commands)
 #                                    Statuses can still be read.
 #                                    Exceptions ("set"-commands) that 
@@ -372,7 +376,20 @@
 #      Motion is triggerd with a positive edge on <execute> input.
 #      returns 0 if success or error code.
 # 
-#   3. retvalue = mc_move_vel(
+#   3. retvalue = mc_move_ext_pos(
+#                           <axIndex>,       : Axis index
+#                           <execute>,       : Trigger
+#                           <vel>,           : Target velocity
+#                           <acc>,           : Acceleration
+#                           <dec>            : Deceleration
+#                           );
+#      Move to current external plc position. Functions intended use is to 
+#      move to the start position for syncronized axes. This command is exactly 
+#      the same as issueing "mc_move_pos()" with the target postion ax<id>.traj.extsetpos.
+#      Motion is triggerd with a positive edge on <execute> input.
+#      returns 0 if success or error code.
+#
+#   4. retvalue = mc_move_vel(
 #                           <axIndex>,       : Axis index
 #                           <execute>,       : Trigger
 #                           <vel>,           : Target velocity
@@ -383,7 +400,7 @@
 #      Motion is triggerd with a positive edge on <execute> input.
 #      returns 0 if success or error code.
 # 
-#   4. retvalue = mc_home(
+#   5. retvalue = mc_home(
 #                           <axIndex>,       : Axis index
 #                           <execute>,       : Trigger
 #                           <seqId>,         : Motion sequence
@@ -394,15 +411,16 @@
 #      Motion is triggerd with a positive edge on <execute> input.
 #      returns 0 if success or error code.
 # 
-#   5. retvalue = mc_halt(
+#   6. retvalue = mc_halt(
 #                           <axIndex>,       : Axis index
 #                           <execute>,       : Trigger
 #                           );
 #      Stop motion of axis <axIndex>.
 #      Motion is triggerd with a positive edge on <execute> input.
 #      returns 0 if success or error code.
+#      Note/Warning: This function will not stop a syncronized motion.
 # 
-#   6. retvalue = mc_power(
+#   7. retvalue = mc_power(
 #                           <axIndex>,       : Axis index
 #                           <enable>,        : Enable power
 #                           );
@@ -410,30 +428,30 @@
 #      Motion is triggerd with a positive edge on <execute> input.
 #      returns 0 if success or error code.
 #
-#   7. retvalue = mc_get_busy(
+#   8. retvalue = mc_get_busy(
 #                           <axIndex>,       : Axis index#                           
 #                           );
 #      Check if axis is busy.
 #
 #      returns busy state of axis (1 if busy and 0 if not busy).
 #
-#   8. retvalue = mc_get_homed(
+#   9. retvalue = mc_get_homed(
 #                           <axIndex>,       : Axis index#                           
 #                           );
 #      Check if axis is homed.
 #
 #      returns state of homed flag of axis (1 if homed and 0 if not homed).
 #
-#   9. retvalue = mc_get_err();
-#      Returns error code for last lib call.
+#   10. retvalue = mc_get_err();
+#       Returns error code for last lib call.
 #   
-#   10. retvalue = mc_reset(<axIndex>);
-#      Resets error of motion axis.
+#   11. retvalue = mc_reset(<axIndex>);
+#       Resets error of motion axis.
 #   
-#   11. retvalue = mc_get_axis_err(<axIndex>);
-#      Returns motion axis error code.
+#   12. retvalue = mc_get_axis_err(<axIndex>);
+#       Returns motion axis error code.
 #   
-#   12. retvalue = mc_set_enable_motion_funcs(
+#   13. retvalue = mc_set_enable_motion_funcs(
 #                           <axIndex>,         : Axis index
 #                           <enablePos>,       : Enable positioning
 #                           <enableVelo>,      : Enable const velo


### PR DESCRIPTION
1. Add example of mc_move_ext_pos():  Move to the external sync.  plc setpoint of an axis.
Intended to be used before axis is accepting external setpoint.

2. Add doc of variables:
  -  ax<id>.enc.extactpos  : Actual position from plc sync expression (ro)
  -  ax<id>.traj.extsetpos : Current trajectory setpoint from plc sync expression (ro)