### PR TITLE
loadPLCFile msi

### DIFF
--- a/general/init.cmd
+++ b/general/init.cmd
@@ -30,12 +30,12 @@
 
 epicsEnvSet("ECMC_ASYN_TIMEOUT",      1)                   # Asyn timeout
 epicsEnvSet("ECMC_ASYN_ADDR",         0)                   # Asyn Address
-epicsEnvSet("ECMC_MOTOR_PORT",        "NOT SET")
+${ECMC_SUPPORT_MOTION=""}epicsEnvSet("ECMC_MOTOR_PORT",        "NOT SET")
 epicsEnvSet("ECMC_ASYN_PORT",         "NOT SET")
 epicsEnvSet("ECMC_PREFIX",            "NOT SET")
 epicsEnvSet("ECMC_GEN_EC_RECORDS",    "NOT SET")
-epicsEnvSet("ECMC_GEN_AX_RECORDS",    "NOT SET")
-epicsEnvSet("ECMC_EC_AXIS_HEALTH",    "NOT SET")
+${ECMC_SUPPORT_MOTION=""}epicsEnvSet("ECMC_GEN_AX_RECORDS",    "NOT SET")
+${ECMC_SUPPORT_MOTION=""}epicsEnvSet("ECMC_EC_AXIS_HEALTH",    "NOT SET")
 epicsEnvSet("ECMC_PLC_SAMPLE_RATE_MS", "NOT SET")
 
 #- ECMC_TIME_SOURCE:
@@ -44,11 +44,11 @@ epicsEnvSet("ECMC_PLC_SAMPLE_RATE_MS", "NOT SET")
 epicsEnvSet("ECMC_TSE",               -2)
 
 #- Init all axis related variables
-ecmcFileExist("${ECMC_CONFIG_ROOT}initAxis.cmd",1)
-${SCRIPTEXEC} "${ECMC_CONFIG_ROOT}initAxis.cmd"
+${ECMC_SUPPORT_MOTION=""}ecmcFileExist("${ECMC_CONFIG_ROOT}initAxis.cmd",1)
+${ECMC_SUPPORT_MOTION=""}${SCRIPTEXEC} "${ECMC_CONFIG_ROOT}initAxis.cmd"
 
 #- Additional parameters when motor Records are loaded
-epicsEnvSet("ECMC_EGU",               "mm")
-epicsEnvSet("ECMC_PREC",              3)
-epicsEnvSet("ECMC_AXISFIELDINIT",     "")                  # Extra field init to motor record
-epicsEnvSet("ECMC_AXISCONFIG",        "")                  # Extra parameters to driver
+${ECMC_SUPPORT_MOTION=""}epicsEnvSet("ECMC_EGU",               "mm")
+${ECMC_SUPPORT_MOTION=""}epicsEnvSet("ECMC_PREC",              3)
+${ECMC_SUPPORT_MOTION=""}epicsEnvSet("ECMC_AXISFIELDINIT",     "")                  # Extra field init to motor record
+${ECMC_SUPPORT_MOTION=""}epicsEnvSet("ECMC_AXISCONFIG",        "")                  # Extra parameters to driver

--- a/scripts/loadPLCFile.cmd
+++ b/scripts/loadPLCFile.cmd
@@ -12,6 +12,7 @@
 #-d   \param SAMPLE_RATE_MS (optional) excecution rate, default 1000/EC_RATE
 #-d   \param PLC_MACROS (optional) Substitution macros for PLC code
 #-d   \param TMP_PATH (optional) directory to dump the temporary plc file after macro substitution
+#-d   \param PRINT_PLC_FILE (optional) 1/0, printout msi parsed plc file (default enable(1)).
 #-d   \note Example call:
 #-d   \code
 #-d     ${SCRIPTEXEC} ${ecmccfg_DIR}loadPLCFile.cmd, "PLC_ID=0, FILE=./plc/homeSlit.plc, SAMPLE_RATE_MS=100"
@@ -32,7 +33,14 @@ epicsEnvSet("ECMC_TMP_FILE",            "${TMP_PATH=/tmp}/PLC${ECMC_PLC_ID}.plc"
 
 #- Convert file with optional macros (msi)
 ecmcFileExist("${FILE}",1)
-system "msi -V -M '${PLC_MACROS=EMPTY}' ${FILE} > ${ECMC_TMP_FILE}"
+system "msi -V -M '${PLC_MACROS=EMPTY}' -o ${ECMC_TMP_FILE} ${FILE}"
+
+#- Printout parsed file?
+ecmcEpicsEnvSetCalcTernary(ECMC_EXE_CMD, ${PRINT_PLC_FILE=1}=1,"", "#-"  )
+${ECMC_EXE_CMD=""}# Parsed PLC file below:
+${ECMC_EXE_CMD=""}system "cat ${ECMC_TMP_FILE}"
+epicsEnvUnset(ECMC_EXE_CMD)
+
 ecmcFileExist("${ECMC_TMP_FILE}",1)
 ecmcConfigOrDie "Cfg.CreatePLC(${ECMC_PLC_ID},${ECMC_PLC_SAMPLE_RATE_MS})"
 ecmcConfigOrDie "Cfg.LoadPLCFile(${ECMC_PLC_ID},${ECMC_TMP_FILE})"


### PR DESCRIPTION
1. Use "-o" for msi parsing to avoid empty file if msi is not in path.
2. Do not execute initAxis.cmd and more if in DAQ mode