### PR TITLE
Adding Festo valvebox VAEM-L1-S-16-PT to configuration database

### DIFF
--- a/db/Festo/ecmcFesto.substitutions
+++ b/db/Festo/ecmcFesto.substitutions
@@ -1,0 +1,6 @@
+# binaryOutArray01/02
+file "ecmc_binaryOutputArray-chX.template" { pattern
+  { CH_ID }
+  { 01    }
+  { 02    }
+}

--- a/hardware/Festo/ecmcFesto-VAEM-L1-S-16-PT.cmd
+++ b/hardware/Festo/ecmcFesto-VAEM-L1-S-16-PT.cmd
@@ -1,0 +1,16 @@
+#-d /**
+#-d   \brief hardware script for Festo VAEM-L1-S-16-PT
+#-d   \author Alvin Acerbo
+#-d   \file
+#-d */
+
+epicsEnvSet("ECMC_EC_HWTYPE"             "Festo")
+epicsEnvSet("ECMC_EC_VENDOR_ID"          "0x0000001d")
+epicsEnvSet("ECMC_EC_PRODUCT_ID"         "0x0008bc8c")
+
+#- verify slave
+ecmcFileExist(${ecmccfg_DIR}slaveVerify.cmd,1)
+${SCRIPTEXEC} ${ecmccfg_DIR}slaveVerify.cmd
+
+ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x7000,0x1,16,binaryOutputArray01)"
+ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x7000,0x2,16,binaryOutputArray02)"


### PR DESCRIPTION
Scope:
This commit is for the Festo CTEU-PN bus node with 16 VAEM-L1-S-16-PT sub-modules.

Limitations of this configuration file:
The Festo bus node CTEU-PN controls the Festo VAEM-L1-S-16-PT sub-modules, which are individual valves. A typical setup uses 16 valves. The bus node by design will report two input/output channels per sub-module, regardless of the type of sub-module. In the case of the VAEM-L1-S-16-PT sub-module, there is only 1 channel. This leads to every second channel not being used, which makes direct indexing of the 16-valves a bit tricky when using an EPICS MBBO record. The PDO mapping of the channels is limited to 16-bits, and hence done in two sets: BO01 controls channels 0-15, BO02 controls channels 16-31.

On the EPICS IOC level, a PLC can be used to re-map the 16 relevant channels of the 32 channel register into a single EPICS AO record and a readback into a single AI record. By this method, a single decimal value written to the PV controls all valves directly, and the EPICS PV can then be easily displayed with for example the CaQtDM caByteControl object.

This ECMC PLC code performs an ECMC to EPICS PV conversion:
```
static.festo_bio_rb := 0;
for (static.i := 0; static.i < 8; static.i += 1) {
  static.festo_bio_rb += ec_chk_bit(ec1.s0.binaryOutputArray01,2*static.i)*2^static.i;
  static.festo_bio_rb += ec_chk_bit(ec1.s0.binaryOutputArray02,2*static.i)*2^(static.i+8);
};
```

And this ECMC PLC code performs an EPICS PV to ECMC conversion:
```
for (static.i := 0; static.i < 8; static.i += 1) {
  ec1.s0.binaryOutputArray01 := ec_wrt_bit(ec1.s0.binaryOutputArray01,ec_chk_bit(static.festo_bio,static.i),static.i*2);
  ec1.s0.binaryOutputArray02 := ec_wrt_bit(ec1.s0.binaryOutputArray02,ec_chk_bit(static.festo_bio,static.i+8),static.i*2);
};
```

And the following EPICS records in support:
```
# Readback of EtherCAT AO registry
record(ai,"$(DEVICE):BIO-RB") {
    field(PINI, "1")
    field(TSE, -2)
    field(DTYP, "asynFloat64")
    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=0))T_SMP_MS=10/TYPE=asynFloat64/plcs.plc1.static.festo_bio_rb?")
    field(PREC, "$(PREC=5)")
    field(SCAN, "I/O Intr")
    field(TSE,  "$(TSE=-2)")
 }

# Setting of EtherCAT AO registry
record(ao,"$(DEVICE):BIO") {
    field(PINI, "1")
    field(DTYP, "asynFloat64")
    field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=0))T_SMP_MS=10/TYPE=asynFloat64/plcs.plc1.static.festo_bio=")
    field(PREC, "$(PREC=5)")
    field(SCAN, "Passive")
    field(TSE,  "$(TSE=-2)")
}
```