### PR TITLE
fix panel layout to be resizable

### DIFF
--- a/qt/ecmcAxis_v10.ui
+++ b/qt/ecmcAxis_v10.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>315</width>
-    <height>410</height>
+    <height>488</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,8 +18,8 @@
     <rect>
      <x>0</x>
      <y>30</y>
-     <width>230</width>
-     <height>386</height>
+     <width>231</width>
+     <height>455</height>
     </rect>
    </property>
    <property name="sizePolicy">
@@ -32,12 +32,6 @@
     <size>
      <width>230</width>
      <height>386</height>
-    </size>
-   </property>
-   <property name="maximumSize">
-    <size>
-     <width>205</width>
-     <height>385</height>
     </size>
    </property>
    <property name="currentIndex">
@@ -71,1101 +65,33 @@
        <property name="title">
         <string>axis</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_3" stretch="1,1,0,12,5">
-        <property name="spacing">
-         <number>2</number>
-        </property>
-        <property name="margin">
-         <number>1</number>
-        </property>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_9">
-          <item>
-           <widget class="caToggleButton" name="catogglebutton">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>enable</string>
-            </property>
-            <property name="channel" stdset="0">
-             <string notr="true">$(SYS):$(Axis).CNEN</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>13</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_8" stretch="4,1">
-            <item>
-             <widget class="caLabel" name="calabel_21">
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>22</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>error:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="caLed" name="caled_15">
-              <property name="rectangular">
-               <bool>true</bool>
-              </property>
-              <property name="gradientEnabled">
-               <bool>false</bool>
-              </property>
-              <property name="ledWidth">
-               <number>12</number>
-              </property>
-              <property name="ledHeight">
-               <number>12</number>
-              </property>
-              <property name="channel" stdset="0">
-               <string notr="true">$(SYS):$(Axis)-ErrId</string>
-              </property>
-              <property name="falseColor">
-               <color>
-                <red>0</red>
-                <green>85</green>
-                <blue>0</blue>
-               </color>
-              </property>
-              <property name="trueColor">
-               <color>
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </property>
-              <property name="undefinedColor">
-               <color>
-                <red>255</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </property>
-              <property name="trueValue">
-               <string notr="true"/>
-              </property>
-              <property name="falseValue">
-               <string notr="true">0</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBox_error_2">
-          <property name="minimumSize">
-           <size>
-            <width>220</width>
-            <height>35</height>
-           </size>
-          </property>
-          <property name="title">
-           <string>trajectory source</string>
-          </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <layout class="QGridLayout" name="gridLayout">
-           <property name="leftMargin">
-            <number>2</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>2</number>
-           </property>
-           <property name="bottomMargin">
-            <number>1</number>
-           </property>
-           <item row="0" column="0">
-            <widget class="caMenu" name="camenu">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>18</height>
-              </size>
-             </property>
-             <property name="layoutDirection">
-              <enum>Qt::LeftToRight</enum>
-             </property>
-             <property name="channel" stdset="0">
-              <string notr="true">$(SYS):$(Axis)-TrjSrcTyp-Cmd</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="caLineEdit" name="calineedit_14">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>18</height>
-              </size>
-             </property>
-             <property name="channel" stdset="0">
-              <string notr="true">$(SYS):$(Axis)-TrjSrcTyp-RB</string>
-             </property>
-             <property name="precisionMode">
-              <enum>caLineEdit::Channel</enum>
-             </property>
-             <property name="limitsMode">
-              <enum>caLineEdit::User</enum>
-             </property>
-             <property name="unitsEnabled">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBox_error_4">
-          <property name="minimumSize">
-           <size>
-            <width>220</width>
-            <height>70</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="title">
-           <string>PLC</string>
-          </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_4">
-           <property name="horizontalSpacing">
-            <number>0</number>
-           </property>
-           <property name="verticalSpacing">
-            <number>2</number>
-           </property>
-           <property name="margin">
-            <number>1</number>
-           </property>
-           <item row="0" column="1">
-            <widget class="caFrame" name="StatusFrame_17">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>20</height>
-              </size>
-             </property>
-             <property name="frameShape">
-              <enum>QFrame::Box</enum>
-             </property>
-             <widget class="caToggleButton" name="catogglebutton_3">
-              <property name="geometry">
-               <rect>
-                <x>10</x>
-                <y>10</y>
-                <width>100</width>
-                <height>16</height>
-               </rect>
-              </property>
-              <property name="text">
-               <string>enable</string>
-              </property>
-              <property name="channel" stdset="0">
-               <string notr="true">$(SYS):$(Axis)-PLC-EnaCmd</string>
-              </property>
-              <property name="colorMode">
-               <enum>caToggleButton::Default</enum>
-              </property>
-             </widget>
-             <widget class="caToggleButton" name="catogglebutton_8">
-              <property name="geometry">
-               <rect>
-                <x>10</x>
-                <y>30</y>
-                <width>100</width>
-                <height>16</height>
-               </rect>
-              </property>
-              <property name="text">
-               <string>ext. commands</string>
-              </property>
-              <property name="channel" stdset="0">
-               <string notr="true">$(SYS):$(Axis)-CmdFrmPLCCmd</string>
-              </property>
-             </widget>
-             <widget class="caLineEdit" name="caLineEdit_43">
-              <property name="geometry">
-               <rect>
-                <x>130</x>
-                <y>10</y>
-                <width>81</width>
-                <height>16</height>
-               </rect>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignAbsolute|Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-              <property name="channel" stdset="0">
-               <string notr="true">$(SYS):$(Axis)-PLC-EnaCmd-RB</string>
-              </property>
-              <property name="foreground">
-               <color>
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </property>
-              <property name="background">
-               <color>
-                <red>216</red>
-                <green>216</green>
-                <blue>216</blue>
-               </color>
-              </property>
-              <property name="colorMode">
-               <enum>caLineEdit::Default</enum>
-              </property>
-              <property name="precisionMode">
-               <enum>caLineEdit::Channel</enum>
-              </property>
-              <property name="limitsMode">
-               <enum>caLineEdit::Channel</enum>
-              </property>
-              <property name="maxValue">
-               <double>1.000000000000000</double>
-              </property>
-              <property name="minValue">
-               <double>0.000000000000000</double>
-              </property>
-              <property name="fontScaleMode" stdset="0">
-               <enum>caLineEdit::WidthAndHeight</enum>
-              </property>
-              <property name="unitsEnabled">
-               <bool>true</bool>
-              </property>
-              <property name="formatType">
-               <enum>caLineEdit::decimal</enum>
-              </property>
-             </widget>
-             <widget class="caLineEdit" name="caLineEdit_44">
-              <property name="geometry">
-               <rect>
-                <x>130</x>
-                <y>30</y>
-                <width>81</width>
-                <height>16</height>
-               </rect>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignAbsolute|Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-              <property name="channel" stdset="0">
-               <string notr="true">$(SYS):$(Axis)-PLC-EnaCmd-RB</string>
-              </property>
-              <property name="foreground">
-               <color>
-                <red>0</red>
-                <green>0</green>
-                <blue>0</blue>
-               </color>
-              </property>
-              <property name="background">
-               <color>
-                <red>216</red>
-                <green>216</green>
-                <blue>216</blue>
-               </color>
-              </property>
-              <property name="colorMode">
-               <enum>caLineEdit::Default</enum>
-              </property>
-              <property name="precisionMode">
-               <enum>caLineEdit::Channel</enum>
-              </property>
-              <property name="limitsMode">
-               <enum>caLineEdit::Channel</enum>
-              </property>
-              <property name="maxValue">
-               <double>1.000000000000000</double>
-              </property>
-              <property name="minValue">
-               <double>0.000000000000000</double>
-              </property>
-              <property name="fontScaleMode" stdset="0">
-               <enum>caLineEdit::WidthAndHeight</enum>
-              </property>
-              <property name="unitsEnabled">
-               <bool>true</bool>
-              </property>
-              <property name="formatType">
-               <enum>caLineEdit::decimal</enum>
-              </property>
-             </widget>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBox_error_3">
-          <property name="minimumSize">
-           <size>
-            <width>220</width>
-            <height>40</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="title">
-           <string>position</string>
-          </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_3">
-           <property name="leftMargin">
-            <number>1</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>1</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <property name="verticalSpacing">
-            <number>2</number>
-           </property>
-           <item row="0" column="0">
-            <widget class="QGroupBox" name="groupBox_5">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="minimumSize">
-              <size>
-               <width>215</width>
-               <height>60</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="title">
-              <string>motorRecord</string>
-             </property>
-             <widget class="caLineEdit" name="calineedit_13">
-              <property name="geometry">
-               <rect>
-                <x>90</x>
-                <y>20</y>
-                <width>100</width>
-                <height>18</height>
-               </rect>
-              </property>
-              <property name="channel" stdset="0">
-               <string notr="true">$(SYS):$(Axis).RBV</string>
-              </property>
-              <property name="precisionMode">
-               <enum>caLineEdit::Channel</enum>
-              </property>
-              <property name="limitsMode">
-               <enum>caLineEdit::User</enum>
-              </property>
-              <property name="unitsEnabled">
-               <bool>true</bool>
-              </property>
-             </widget>
-             <widget class="caLabel" name="calabel_32">
-              <property name="geometry">
-               <rect>
-                <x>5</x>
-                <y>20</y>
-                <width>80</width>
-                <height>18</height>
-               </rect>
-              </property>
-              <property name="text">
-               <string>readback:</string>
-              </property>
-             </widget>
-             <widget class="caLabel" name="calabel_33">
-              <property name="geometry">
-               <rect>
-                <x>5</x>
-                <y>40</y>
-                <width>80</width>
-                <height>18</height>
-               </rect>
-              </property>
-              <property name="text">
-               <string>setpoint:</string>
-              </property>
-             </widget>
-             <widget class="caRelatedDisplay" name="carelateddisplay_6">
-              <property name="geometry">
-               <rect>
-                <x>195</x>
-                <y>10</y>
-                <width>18</width>
-                <height>18</height>
-               </rect>
-              </property>
-              <property name="labels">
-               <string>R</string>
-              </property>
-              <property name="files">
-               <string>motorx_all.ui</string>
-              </property>
-              <property name="args">
-               <string>P=$(SYS):,M=$(Axis)</string>
-              </property>
-             </widget>
-             <widget class="QWidget" name="layoutWidget_4">
-              <property name="geometry">
-               <rect>
-                <x>90</x>
-                <y>40</y>
-                <width>101</width>
-                <height>19</height>
-               </rect>
-              </property>
-              <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="2,1">
-               <property name="spacing">
-                <number>2</number>
-               </property>
-               <item>
-                <widget class="caTextEntry" name="catextentry_6">
-                 <property name="channel" stdset="0">
-                  <string notr="true">$(SYS):$(Axis).VAL</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="caLineEdit" name="calineedit_20">
-                 <property name="channel" stdset="0">
-                  <string notr="true">$(SYS):$(Axis).EGU</string>
-                 </property>
-                 <property name="precisionMode">
-                  <enum>caLineEdit::Channel</enum>
-                 </property>
-                 <property name="limitsMode">
-                  <enum>caLineEdit::User</enum>
-                 </property>
-                 <property name="unitsEnabled">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QGroupBox" name="groupBox_6">
-             <property name="minimumSize">
-              <size>
-               <width>215</width>
-               <height>65</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="title">
-              <string>ECMC</string>
-             </property>
-             <property name="flat">
-              <bool>false</bool>
-             </property>
-             <property name="checkable">
-              <bool>false</bool>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_8" columnstretch="1,2" columnminimumwidth="0,0">
-              <property name="verticalSpacing">
-               <number>2</number>
-              </property>
-              <property name="margin">
-               <number>1</number>
-              </property>
-              <item row="0" column="0">
-               <widget class="caLabel" name="calabel_30">
-                <property name="text">
-                 <string>actual:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="caLineEdit" name="calineedit_12">
-                <property name="channel" stdset="0">
-                 <string notr="true">$(SYS):$(Axis)-PosAct</string>
-                </property>
-                <property name="precisionMode">
-                 <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="limitsMode">
-                 <enum>caLineEdit::User</enum>
-                </property>
-                <property name="unitsEnabled">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="caLabel" name="calabel_31">
-                <property name="text">
-                 <string>planned:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="caLineEdit" name="calineedit_21">
-                <property name="channel" stdset="0">
-                 <string notr="true">$(SYS):$(Axis)-PosSet</string>
-                </property>
-                <property name="precisionMode">
-                 <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="limitsMode">
-                 <enum>caLineEdit::User</enum>
-                </property>
-                <property name="unitsEnabled">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="caLabel" name="calabel_45">
-                <property name="text">
-                 <string>deviation:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="caLineEdit" name="calineedit_22">
-                <property name="channel" stdset="0">
-                 <string notr="true">$(SYS):$(Axis)-PosErr</string>
-                </property>
-                <property name="precisionMode">
-                 <enum>caLineEdit::Channel</enum>
-                </property>
-                <property name="limitsMode">
-                 <enum>caLineEdit::User</enum>
-                </property>
-                <property name="unitsEnabled">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBox_error">
-          <property name="minimumSize">
-           <size>
-            <width>220</width>
-            <height>40</height>
-           </size>
-          </property>
-          <property name="title">
-           <string>error</string>
-          </property>
-          <property name="flat">
-           <bool>true</bool>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_2">
-           <property name="leftMargin">
-            <number>2</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>2</number>
-           </property>
-           <property name="bottomMargin">
-            <number>1</number>
-           </property>
-           <item row="0" column="1">
-            <widget class="caLineEdit" name="calineedit_4">
-             <property name="minimumSize">
-              <size>
-               <width>25</width>
-               <height>18</height>
-              </size>
-             </property>
-             <property name="channel" stdset="0">
-              <string notr="true">$(SYS):$(Axis)-ErrId</string>
-             </property>
-             <property name="precisionMode">
-              <enum>caLineEdit::User</enum>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="caLabel" name="calabel_8">
-             <property name="minimumSize">
-              <size>
-               <width>18</width>
-               <height>18</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>#</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2">
-            <widget class="caMessageButton" name="camessagebutton">
-             <property name="minimumSize">
-              <size>
-               <width>50</width>
-               <height>18</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>error reset</string>
-             </property>
-             <property name="channel" stdset="0">
-              <string notr="true">$(SYS):$(Axis)-ErrRst</string>
-             </property>
-             <property name="label">
-              <string notr="true">error reset</string>
-             </property>
-             <property name="releaseMessage">
-              <string notr="true">0</string>
-             </property>
-             <property name="pressMessage">
-              <string notr="true">1</string>
-             </property>
-             <property name="colorMode">
-              <enum>caMessageButton::Default</enum>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0" colspan="3">
-            <widget class="caLineEdit" name="calineedit_7">
-             <property name="channel" stdset="0">
-              <string notr="true">$(SYS):$(Axis)-MsgTxt</string>
-             </property>
-             <property name="colorMode">
-              <enum>caLineEdit::Default</enum>
-             </property>
-             <property name="alarmHandling">
-              <enum>caLineEdit::onBackground</enum>
-             </property>
-             <property name="precisionMode">
-              <enum>caLineEdit::User</enum>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
-   </widget>
-   <widget class="QWidget" name="motion">
-    <attribute name="title">
-     <string>Motion</string>
-    </attribute>
-    <layout class="QGridLayout" name="gridLayout_7">
-     <property name="margin">
-      <number>0</number>
-     </property>
-     <property name="spacing">
-      <number>2</number>
-     </property>
-     <item row="2" column="0">
-      <spacer name="verticalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>82</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="0" column="0">
-      <widget class="caFrame" name="StatusFrame_10">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>160</height>
-        </size>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::Box</enum>
-       </property>
-       <widget class="caFrame" name="StatusFrame_11">
+       <widget class="QGroupBox" name="groupBox_error_2">
         <property name="geometry">
          <rect>
-          <x>0</x>
-          <y>19</y>
-          <width>201</width>
-          <height>21</height>
+          <x>3</x>
+          <y>50</y>
+          <width>221</width>
+          <height>41</height>
          </rect>
         </property>
         <property name="minimumSize">
          <size>
-          <width>0</width>
-          <height>20</height>
+          <width>220</width>
+          <height>35</height>
          </size>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::Box</enum>
+        <property name="title">
+         <string>trajectory source</string>
         </property>
-        <widget class="caLineEdit" name="calineedit_33">
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+        <widget class="caMenu" name="camenu">
          <property name="geometry">
           <rect>
-           <x>100</x>
-           <y>1</y>
-           <width>99</width>
-           <height>16</height>
-          </rect>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="channel" stdset="0">
-          <string notr="true">$(SYS):$(Axis)-VelAct</string>
-         </property>
-         <property name="background">
-          <color alpha="222">
-           <red>192</red>
-           <green>192</green>
-           <blue>192</blue>
-          </color>
-         </property>
-         <property name="colorMode">
-          <enum>caLineEdit::Static</enum>
-         </property>
-         <property name="precisionMode">
-          <enum>caLineEdit::Channel</enum>
-         </property>
-         <property name="limitsMode">
-          <enum>caLineEdit::User</enum>
-         </property>
-         <property name="unitsEnabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-        <widget class="caLabel" name="calabel_57">
-         <property name="geometry">
-          <rect>
-           <x>20</x>
-           <y>1</y>
-           <width>80</width>
-           <height>16</height>
-          </rect>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>VelAct: </string>
-         </property>
-        </widget>
-       </widget>
-       <widget class="caFrame" name="StatusFrame_12">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>40</y>
-          <width>201</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>20</height>
-         </size>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::Box</enum>
-        </property>
-        <widget class="caLabel" name="calabel_62">
-         <property name="geometry">
-          <rect>
-           <x>20</x>
-           <y>1</y>
-           <width>80</width>
-           <height>16</height>
-          </rect>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>TgtPos: </string>
-         </property>
-        </widget>
-        <widget class="caTextEntry" name="catextentry_13">
-         <property name="geometry">
-          <rect>
-           <x>100</x>
-           <y>1</y>
-           <width>70</width>
-           <height>15</height>
-          </rect>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="readOnly">
-          <bool>false</bool>
-         </property>
-         <property name="channel" stdset="0">
-          <string notr="true">$(SYS):$(Axis)-TgtPosCmd</string>
-         </property>
-         <property name="keepFocus">
-          <bool>true</bool>
-         </property>
-        </widget>
-        <widget class="caLineEdit" name="calineedit_35">
-         <property name="geometry">
-          <rect>
-           <x>170</x>
-           <y>2</y>
-           <width>29</width>
-           <height>16</height>
-          </rect>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="channel" stdset="0">
-          <string notr="true">$(SYS):$(Axis)-TgtPosCmd.EGU</string>
-         </property>
-         <property name="background">
-          <color alpha="222">
-           <red>192</red>
-           <green>192</green>
-           <blue>192</blue>
-          </color>
-         </property>
-         <property name="colorMode">
-          <enum>caLineEdit::Static</enum>
-         </property>
-         <property name="precisionMode">
-          <enum>caLineEdit::Channel</enum>
-         </property>
-         <property name="limitsMode">
-          <enum>caLineEdit::User</enum>
-         </property>
-         <property name="unitsEnabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </widget>
-       <widget class="caFrame" name="StatusFrame_13">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>60</y>
-          <width>201</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>20</height>
-         </size>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::Box</enum>
-        </property>
-        <widget class="caLabel" name="calabel_63">
-         <property name="geometry">
-          <rect>
-           <x>20</x>
-           <y>1</y>
-           <width>80</width>
-           <height>16</height>
-          </rect>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>TgtVel: </string>
-         </property>
-        </widget>
-        <widget class="caTextEntry" name="catextentry_16">
-         <property name="geometry">
-          <rect>
-           <x>100</x>
-           <y>1</y>
-           <width>70</width>
-           <height>15</height>
-          </rect>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="readOnly">
-          <bool>false</bool>
-         </property>
-         <property name="channel" stdset="0">
-          <string notr="true">$(SYS):$(Axis)-TgtVelCmd</string>
-         </property>
-         <property name="keepFocus">
-          <bool>true</bool>
-         </property>
-        </widget>
-        <widget class="caLineEdit" name="calineedit_36">
-         <property name="geometry">
-          <rect>
-           <x>170</x>
-           <y>2</y>
-           <width>29</width>
-           <height>16</height>
-          </rect>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>18</height>
-          </size>
-         </property>
-         <property name="channel" stdset="0">
-          <string notr="true">$(SYS):$(Axis)-TgtVelCmd.EGU</string>
-         </property>
-         <property name="background">
-          <color alpha="222">
-           <red>192</red>
-           <green>192</green>
-           <blue>192</blue>
-          </color>
-         </property>
-         <property name="colorMode">
-          <enum>caLineEdit::Static</enum>
-         </property>
-         <property name="precisionMode">
-          <enum>caLineEdit::Channel</enum>
-         </property>
-         <property name="limitsMode">
-          <enum>caLineEdit::User</enum>
-         </property>
-         <property name="unitsEnabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </widget>
-       <widget class="caFrame" name="StatusFrame_14">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>80</y>
-          <width>200</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>20</height>
-         </size>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::Box</enum>
-        </property>
-        <widget class="caLabel" name="calabel_46">
-         <property name="geometry">
-          <rect>
-           <x>20</x>
-           <y>1</y>
-           <width>80</width>
-           <height>16</height>
-          </rect>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>type: </string>
-         </property>
-        </widget>
-        <widget class="caMenu" name="camenu_4">
-         <property name="geometry">
-          <rect>
-           <x>100</x>
-           <y>1</y>
-           <width>80</width>
+           <x>4</x>
+           <y>21</y>
+           <width>103</width>
            <height>18</height>
           </rect>
          </property>
@@ -1175,65 +101,30 @@
            <height>18</height>
           </size>
          </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>18</height>
-          </size>
-         </property>
          <property name="layoutDirection">
           <enum>Qt::LeftToRight</enum>
          </property>
          <property name="channel" stdset="0">
-          <string notr="true">$(SYS):$(Axis)-MtnCmd</string>
+          <string notr="true">$(SYS):$(Axis)-TrjSrcTyp-Cmd</string>
          </property>
         </widget>
-       </widget>
-       <widget class="caFrame" name="StatusFrame_15">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>0</y>
-          <width>201</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>20</height>
-         </size>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::Box</enum>
-        </property>
-        <widget class="caLineEdit" name="calineedit_37">
+        <widget class="caLineEdit" name="calineedit_14">
          <property name="geometry">
           <rect>
-           <x>100</x>
-           <y>1</y>
-           <width>99</width>
-           <height>16</height>
+           <x>114</x>
+           <y>21</y>
+           <width>102</width>
+           <height>18</height>
           </rect>
          </property>
-         <property name="maximumSize">
+         <property name="minimumSize">
           <size>
-           <width>16777215</width>
+           <width>0</width>
            <height>18</height>
           </size>
          </property>
          <property name="channel" stdset="0">
-          <string notr="true">$(SYS):$(Axis)-PosAct</string>
-         </property>
-         <property name="background">
-          <color alpha="222">
-           <red>192</red>
-           <green>192</green>
-           <blue>192</blue>
-          </color>
-         </property>
-         <property name="colorMode">
-          <enum>caLineEdit::Static</enum>
+          <string notr="true">$(SYS):$(Axis)-TrjSrcTyp-RB</string>
          </property>
          <property name="precisionMode">
           <enum>caLineEdit::Channel</enum>
@@ -1245,374 +136,1509 @@
           <bool>true</bool>
          </property>
         </widget>
-        <widget class="caLabel" name="calabel_64">
-         <property name="geometry">
-          <rect>
-           <x>20</x>
-           <y>1</y>
-           <width>80</width>
-           <height>16</height>
-          </rect>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>PosAct: </string>
-         </property>
-        </widget>
        </widget>
-       <widget class="caFrame" name="StatusFrame_16">
+       <widget class="QGroupBox" name="groupBox_error_4">
         <property name="geometry">
          <rect>
-          <x>110</x>
-          <y>100</y>
-          <width>91</width>
-          <height>61</height>
+          <x>3</x>
+          <y>90</y>
+          <width>220</width>
+          <height>91</height>
          </rect>
         </property>
         <property name="minimumSize">
          <size>
-          <width>0</width>
-          <height>20</height>
+          <width>220</width>
+          <height>70</height>
          </size>
         </property>
-        <property name="frameShape">
-         <enum>QFrame::Box</enum>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
         </property>
-        <widget class="caToggleButton" name="catogglebutton_5">
+        <property name="title">
+         <string>PLC</string>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <property name="horizontalSpacing">
+          <number>0</number>
+         </property>
+         <property name="verticalSpacing">
+          <number>2</number>
+         </property>
+         <property name="margin">
+          <number>1</number>
+         </property>
+         <item row="0" column="1">
+          <widget class="caFrame" name="StatusFrame_17">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::Box</enum>
+           </property>
+           <widget class="caToggleButton" name="catogglebutton_3">
+            <property name="geometry">
+             <rect>
+              <x>10</x>
+              <y>10</y>
+              <width>100</width>
+              <height>18</height>
+             </rect>
+            </property>
+            <property name="text">
+             <string>enable</string>
+            </property>
+            <property name="channel" stdset="0">
+             <string notr="true">$(SYS):$(Axis)-PLC-EnaCmd</string>
+            </property>
+            <property name="colorMode">
+             <enum>caToggleButton::Default</enum>
+            </property>
+           </widget>
+           <widget class="caToggleButton" name="catogglebutton_8">
+            <property name="geometry">
+             <rect>
+              <x>10</x>
+              <y>30</y>
+              <width>111</width>
+              <height>18</height>
+             </rect>
+            </property>
+            <property name="text">
+             <string>ext. commands</string>
+            </property>
+            <property name="channel" stdset="0">
+             <string notr="true">$(SYS):$(Axis)-CmdFrmPLCCmd</string>
+            </property>
+           </widget>
+           <widget class="caLineEdit" name="caLineEdit_43">
+            <property name="geometry">
+             <rect>
+              <x>130</x>
+              <y>10</y>
+              <width>81</width>
+              <height>18</height>
+             </rect>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignAbsolute|Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+            <property name="channel" stdset="0">
+             <string notr="true">$(SYS):$(Axis)-PLC-EnaCmd-RB</string>
+            </property>
+            <property name="foreground">
+             <color>
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+            <property name="background">
+             <color>
+              <red>216</red>
+              <green>216</green>
+              <blue>216</blue>
+             </color>
+            </property>
+            <property name="colorMode">
+             <enum>caLineEdit::Default</enum>
+            </property>
+            <property name="precisionMode">
+             <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+             <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="maxValue">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="minValue">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="fontScaleMode" stdset="0">
+             <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="unitsEnabled">
+             <bool>true</bool>
+            </property>
+            <property name="formatType">
+             <enum>caLineEdit::decimal</enum>
+            </property>
+           </widget>
+           <widget class="caLineEdit" name="caLineEdit_44">
+            <property name="geometry">
+             <rect>
+              <x>130</x>
+              <y>30</y>
+              <width>81</width>
+              <height>18</height>
+             </rect>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignAbsolute|Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+            <property name="channel" stdset="0">
+             <string notr="true">$(SYS):$(Axis)-PLC-EnaCmd-RB</string>
+            </property>
+            <property name="foreground">
+             <color>
+              <red>0</red>
+              <green>0</green>
+              <blue>0</blue>
+             </color>
+            </property>
+            <property name="background">
+             <color>
+              <red>216</red>
+              <green>216</green>
+              <blue>216</blue>
+             </color>
+            </property>
+            <property name="colorMode">
+             <enum>caLineEdit::Default</enum>
+            </property>
+            <property name="precisionMode">
+             <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="limitsMode">
+             <enum>caLineEdit::Channel</enum>
+            </property>
+            <property name="maxValue">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="minValue">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="fontScaleMode" stdset="0">
+             <enum>caLineEdit::WidthAndHeight</enum>
+            </property>
+            <property name="unitsEnabled">
+             <bool>true</bool>
+            </property>
+            <property name="formatType">
+             <enum>caLineEdit::decimal</enum>
+            </property>
+           </widget>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QGroupBox" name="groupBox_error_3">
+        <property name="geometry">
+         <rect>
+          <x>3</x>
+          <y>180</y>
+          <width>221</width>
+          <height>181</height>
+         </rect>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>220</width>
+          <height>40</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="title">
+         <string>position</string>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+        <widget class="QGroupBox" name="groupBox_5">
          <property name="geometry">
           <rect>
-           <x>10</x>
-           <y>0</y>
-           <width>51</width>
-           <height>16</height>
+           <x>3</x>
+           <y>19</y>
+           <width>215</width>
+           <height>65</height>
           </rect>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>215</width>
+           <height>65</height>
+          </size>
          </property>
          <property name="maximumSize">
           <size>
            <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>motorRecord</string>
+         </property>
+         <widget class="caLineEdit" name="calineedit_13">
+          <property name="geometry">
+           <rect>
+            <x>90</x>
+            <y>20</y>
+            <width>100</width>
+            <height>18</height>
+           </rect>
+          </property>
+          <property name="channel" stdset="0">
+           <string notr="true">$(SYS):$(Axis).RBV</string>
+          </property>
+          <property name="precisionMode">
+           <enum>caLineEdit::Channel</enum>
+          </property>
+          <property name="limitsMode">
+           <enum>caLineEdit::User</enum>
+          </property>
+          <property name="unitsEnabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+         <widget class="caLabel" name="calabel_32">
+          <property name="geometry">
+           <rect>
+            <x>5</x>
+            <y>20</y>
+            <width>80</width>
+            <height>18</height>
+           </rect>
+          </property>
+          <property name="text">
+           <string>readback:</string>
+          </property>
+         </widget>
+         <widget class="caLabel" name="calabel_33">
+          <property name="geometry">
+           <rect>
+            <x>5</x>
+            <y>40</y>
+            <width>80</width>
+            <height>18</height>
+           </rect>
+          </property>
+          <property name="text">
+           <string>setpoint:</string>
+          </property>
+         </widget>
+         <widget class="caRelatedDisplay" name="carelateddisplay_6">
+          <property name="geometry">
+           <rect>
+            <x>195</x>
+            <y>10</y>
+            <width>18</width>
+            <height>18</height>
+           </rect>
+          </property>
+          <property name="labels">
+           <string>R</string>
+          </property>
+          <property name="files">
+           <string>motorx_all.ui</string>
+          </property>
+          <property name="args">
+           <string>P=$(SYS):,M=$(Axis)</string>
+          </property>
+         </widget>
+         <widget class="caTextEntry" name="catextentry_6">
+          <property name="geometry">
+           <rect>
+            <x>91</x>
+            <y>41</y>
+            <width>65</width>
+            <height>18</height>
+           </rect>
+          </property>
+          <property name="channel" stdset="0">
+           <string notr="true">$(SYS):$(Axis).VAL</string>
+          </property>
+         </widget>
+         <widget class="caLineEdit" name="calineedit_20">
+          <property name="geometry">
+           <rect>
+            <x>158</x>
+            <y>43</y>
+            <width>32</width>
+            <height>18</height>
+           </rect>
+          </property>
+          <property name="channel" stdset="0">
+           <string notr="true">$(SYS):$(Axis).EGU</string>
+          </property>
+          <property name="precisionMode">
+           <enum>caLineEdit::Channel</enum>
+          </property>
+          <property name="limitsMode">
+           <enum>caLineEdit::User</enum>
+          </property>
+          <property name="unitsEnabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </widget>
+        <widget class="QGroupBox" name="groupBox_6">
+         <property name="geometry">
+          <rect>
+           <x>3</x>
+           <y>90</y>
+           <width>215</width>
+           <height>81</height>
+          </rect>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>215</width>
+           <height>65</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>ECMC</string>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <widget class="caLabel" name="calabel_31">
+          <property name="geometry">
+           <rect>
+            <x>3</x>
+            <y>41</y>
+            <width>50</width>
+            <height>18</height>
+           </rect>
+          </property>
+          <property name="text">
+           <string>planned:</string>
+          </property>
+         </widget>
+         <widget class="caLabel" name="calabel_45">
+          <property name="geometry">
+           <rect>
+            <x>3</x>
+            <y>60</y>
+            <width>60</width>
+            <height>18</height>
+           </rect>
+          </property>
+          <property name="text">
+           <string>deviation:</string>
+          </property>
+         </widget>
+         <widget class="caLineEdit" name="calineedit_12">
+          <property name="geometry">
+           <rect>
+            <x>76</x>
+            <y>22</y>
+            <width>136</width>
+            <height>17</height>
+           </rect>
+          </property>
+          <property name="channel" stdset="0">
+           <string notr="true">$(SYS):$(Axis)-PosAct</string>
+          </property>
+          <property name="precisionMode">
+           <enum>caLineEdit::Channel</enum>
+          </property>
+          <property name="limitsMode">
+           <enum>caLineEdit::User</enum>
+          </property>
+          <property name="unitsEnabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+         <widget class="caLineEdit" name="calineedit_21">
+          <property name="geometry">
+           <rect>
+            <x>76</x>
+            <y>41</y>
+            <width>136</width>
+            <height>17</height>
+           </rect>
+          </property>
+          <property name="channel" stdset="0">
+           <string notr="true">$(SYS):$(Axis)-PosSet</string>
+          </property>
+          <property name="precisionMode">
+           <enum>caLineEdit::Channel</enum>
+          </property>
+          <property name="limitsMode">
+           <enum>caLineEdit::User</enum>
+          </property>
+          <property name="unitsEnabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+         <widget class="caLabel" name="calabel_30">
+          <property name="geometry">
+           <rect>
+            <x>3</x>
+            <y>22</y>
+            <width>50</width>
+            <height>18</height>
+           </rect>
+          </property>
+          <property name="text">
+           <string>actual:</string>
+          </property>
+         </widget>
+         <widget class="caLineEdit" name="calineedit_22">
+          <property name="geometry">
+           <rect>
+            <x>76</x>
+            <y>60</y>
+            <width>136</width>
+            <height>17</height>
+           </rect>
+          </property>
+          <property name="channel" stdset="0">
+           <string notr="true">$(SYS):$(Axis)-PosErr</string>
+          </property>
+          <property name="precisionMode">
+           <enum>caLineEdit::Channel</enum>
+          </property>
+          <property name="limitsMode">
+           <enum>caLineEdit::User</enum>
+          </property>
+          <property name="unitsEnabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </widget>
+       </widget>
+       <widget class="QGroupBox" name="groupBox_error">
+        <property name="geometry">
+         <rect>
+          <x>3</x>
+          <y>353</y>
+          <width>220</width>
+          <height>73</height>
+         </rect>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>220</width>
+          <height>40</height>
+         </size>
+        </property>
+        <property name="title">
+         <string>error</string>
+        </property>
+        <property name="flat">
+         <bool>true</bool>
+        </property>
+        <widget class="caLabel" name="calabel_8">
+         <property name="geometry">
+          <rect>
+           <x>4</x>
+           <y>21</y>
+           <width>18</width>
+           <height>18</height>
+          </rect>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>18</width>
            <height>18</height>
           </size>
          </property>
          <property name="text">
-          <string>enable</string>
-         </property>
-         <property name="channel" stdset="0">
-          <string notr="true">$(SYS):$(Axis)-EnaCmd</string>
+          <string>#</string>
          </property>
         </widget>
-        <widget class="caLed" name="caled_3">
+        <widget class="caMessageButton" name="camessagebutton">
          <property name="geometry">
           <rect>
-           <x>67</x>
-           <y>0</y>
-           <width>18</width>
-           <height>16</height>
+           <x>145</x>
+           <y>21</y>
+           <width>71</width>
+           <height>23</height>
           </rect>
          </property>
-         <property name="rectangular">
-          <bool>true</bool>
-         </property>
-         <property name="gradientEnabled">
-          <bool>false</bool>
-         </property>
-         <property name="channel" stdset="0">
-          <string notr="true">$(SYS):$(Axis)-EnaAct</string>
-         </property>
-         <property name="trueColor">
-          <color>
-           <red>0</red>
-           <green>85</green>
-           <blue>0</blue>
-          </color>
-         </property>
-        </widget>
-        <widget class="caMessageButton" name="camessagebutton_10">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="geometry">
-          <rect>
-           <x>50</x>
-           <y>20</y>
-           <width>33</width>
-           <height>20</height>
-          </rect>
+         <property name="minimumSize">
+          <size>
+           <width>50</width>
+           <height>18</height>
+          </size>
          </property>
          <property name="text">
-          <string>stop</string>
+          <string>error reset</string>
          </property>
          <property name="channel" stdset="0">
-          <string notr="true">$(SYS):$(Axis)-StpCmd</string>
+          <string notr="true">$(SYS):$(Axis)-ErrRst</string>
          </property>
          <property name="label">
-          <string notr="true">stop</string>
-         </property>
-         <property name="foreground">
-          <color>
-           <red>255</red>
-           <green>255</green>
-           <blue>255</blue>
-          </color>
-         </property>
-         <property name="background">
-          <color>
-           <red>170</red>
-           <green>0</green>
-           <blue>0</blue>
-          </color>
-         </property>
-         <property name="disabledForeground">
-          <color>
-           <red>170</red>
-           <green>0</green>
-           <blue>0</blue>
-          </color>
+          <string notr="true">error reset</string>
          </property>
          <property name="releaseMessage">
-          <string notr="true">1</string>
-         </property>
-         <property name="pressMessage">
-          <string notr="true"/>
-         </property>
-        </widget>
-        <widget class="caMessageButton" name="camessagebutton_12">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>20</y>
-           <width>34</width>
-           <height>21</height>
-          </rect>
-         </property>
-         <property name="text">
-          <string>exec</string>
-         </property>
-         <property name="channel" stdset="0">
-          <string notr="true">$(SYS):$(Axis)-ExeCmd</string>
-         </property>
-         <property name="label">
-          <string notr="true">exec</string>
-         </property>
-         <property name="foreground">
-          <color>
-           <red>255</red>
-           <green>255</green>
-           <blue>255</blue>
-          </color>
-         </property>
-         <property name="background">
-          <color>
-           <red>0</red>
-           <green>0</green>
-           <blue>127</blue>
-          </color>
-         </property>
-         <property name="disabledForeground">
-          <color>
-           <red>170</red>
-           <green>0</green>
-           <blue>0</blue>
-          </color>
-         </property>
-         <property name="disableChannel" stdset="0">
-          <string/>
-         </property>
-         <property name="releaseMessage">
-          <string notr="true">1</string>
-         </property>
-         <property name="pressMessage">
           <string notr="true">0</string>
          </property>
+         <property name="pressMessage">
+          <string notr="true">1</string>
+         </property>
+         <property name="colorMode">
+          <enum>caMessageButton::Default</enum>
+         </property>
         </widget>
-        <widget class="caMessageButton" name="camessagebutton_4">
+        <widget class="caLineEdit" name="calineedit_7">
          <property name="geometry">
           <rect>
-           <x>10</x>
-           <y>40</y>
-           <width>75</width>
-           <height>20</height>
+           <x>4</x>
+           <y>50</y>
+           <width>212</width>
+           <height>17</height>
           </rect>
          </property>
          <property name="channel" stdset="0">
-          <string notr="true">$(SYS):$(Axis)-RstCmd</string>
+          <string notr="true">$(SYS):$(Axis)-MsgTxt</string>
          </property>
-         <property name="label">
-          <string notr="true">reset</string>
+         <property name="colorMode">
+          <enum>caLineEdit::Default</enum>
          </property>
-         <property name="releaseMessage">
-          <string notr="true">1</string>
+         <property name="alarmHandling">
+          <enum>caLineEdit::onBackground</enum>
          </property>
-         <property name="pressMessage">
-          <string notr="true"/>
+         <property name="precisionMode">
+          <enum>caLineEdit::User</enum>
+         </property>
+        </widget>
+        <widget class="caLineEdit" name="calineedit_4">
+         <property name="geometry">
+          <rect>
+           <x>27</x>
+           <y>23</y>
+           <width>108</width>
+           <height>18</height>
+          </rect>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>25</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="channel" stdset="0">
+          <string notr="true">$(SYS):$(Axis)-ErrId</string>
+         </property>
+         <property name="precisionMode">
+          <enum>caLineEdit::User</enum>
          </property>
         </widget>
        </widget>
-       <widget class="caFrame" name="caframe_3">
+       <widget class="caToggleButton" name="catogglebutton">
         <property name="geometry">
          <rect>
-          <x>0</x>
-          <y>110</y>
-          <width>111</width>
-          <height>41</height>
+          <x>4</x>
+          <y>23</y>
+          <width>70</width>
+          <height>20</height>
          </rect>
         </property>
-        <property name="background">
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>enable</string>
+        </property>
+        <property name="channel" stdset="0">
+         <string notr="true">$(SYS):$(Axis).CNEN</string>
+        </property>
+       </widget>
+       <widget class="caLabel" name="calabel_21">
+        <property name="geometry">
+         <rect>
+          <x>138</x>
+          <y>22</y>
+          <width>51</width>
+          <height>20</height>
+         </rect>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>error:</string>
+        </property>
+       </widget>
+       <widget class="caLed" name="caled_15">
+        <property name="geometry">
+         <rect>
+          <x>200</x>
+          <y>24</y>
+          <width>16</width>
+          <height>16</height>
+         </rect>
+        </property>
+        <property name="rectangular">
+         <bool>true</bool>
+        </property>
+        <property name="gradientEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="ledWidth">
+         <number>12</number>
+        </property>
+        <property name="ledHeight">
+         <number>12</number>
+        </property>
+        <property name="channel" stdset="0">
+         <string notr="true">$(SYS):$(Axis)-ErrId</string>
+        </property>
+        <property name="falseColor">
+         <color>
+          <red>0</red>
+          <green>85</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="trueColor">
+         <color>
+          <red>0</red>
+          <green>0</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="undefinedColor">
          <color>
           <red>255</red>
           <green>0</green>
           <blue>0</blue>
          </color>
         </property>
-        <property name="backgroundMode">
-         <enum>caFrame::Filled</enum>
+        <property name="trueValue">
+         <string notr="true"/>
         </property>
-        <property name="visibility">
-         <enum>caFrame::IfNotZero</enum>
-        </property>
-        <property name="channel" stdset="0">
-         <string notr="true">$(SYS):$(Axis)-ErrId</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_11">
-         <item row="0" column="0">
-          <widget class="caLabel" name="calabel_4">
-           <property name="text">
-            <string>ERROR</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="foreground">
-            <color>
-             <red>255</red>
-             <green>255</green>
-             <blue>255</blue>
-            </color>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="caFrame" name="StatusFrame_2">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>50</height>
-        </size>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::Box</enum>
-       </property>
-       <widget class="caLabel" name="calabel_10">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>0</y>
-          <width>18</width>
-          <height>20</height>
-         </rect>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>18</width>
-          <height>18</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>#</string>
-        </property>
-       </widget>
-       <widget class="caMessageButton" name="camessagebutton_13">
-        <property name="geometry">
-         <rect>
-          <x>149</x>
-          <y>0</y>
-          <width>70</width>
-          <height>20</height>
-         </rect>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>50</width>
-          <height>18</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>error reset</string>
-        </property>
-        <property name="channel" stdset="0">
-         <string notr="true">$(SYS):$(Axis)-ErrRst</string>
-        </property>
-        <property name="label">
-         <string notr="true">error reset</string>
-        </property>
-        <property name="releaseMessage">
+        <property name="falseValue">
          <string notr="true">0</string>
-        </property>
-        <property name="pressMessage">
-         <string notr="true">1</string>
-        </property>
-        <property name="colorMode">
-         <enum>caMessageButton::Default</enum>
-        </property>
-       </widget>
-       <widget class="caLineEdit" name="calineedit_9">
-        <property name="geometry">
-         <rect>
-          <x>5</x>
-          <y>26</y>
-          <width>190</width>
-          <height>15</height>
-         </rect>
-        </property>
-        <property name="channel" stdset="0">
-         <string notr="true">$(SYS):$(Axis)-MsgTxt</string>
-        </property>
-        <property name="colorMode">
-         <enum>caLineEdit::Default</enum>
-        </property>
-        <property name="alarmHandling">
-         <enum>caLineEdit::onBackground</enum>
-        </property>
-        <property name="precisionMode">
-         <enum>caLineEdit::User</enum>
-        </property>
-       </widget>
-       <widget class="caLineEdit" name="calineedit_6">
-        <property name="geometry">
-         <rect>
-          <x>24</x>
-          <y>1</y>
-          <width>119</width>
-          <height>18</height>
-         </rect>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>25</width>
-          <height>18</height>
-         </size>
-        </property>
-        <property name="channel" stdset="0">
-         <string notr="true">$(SYS):$(Axis)-ErrId</string>
-        </property>
-        <property name="precisionMode">
-         <enum>caLineEdit::User</enum>
         </property>
        </widget>
       </widget>
      </item>
     </layout>
+   </widget>
+   <widget class="QWidget" name="motion">
+    <attribute name="title">
+     <string>Motion</string>
+    </attribute>
+    <widget class="caFrame" name="StatusFrame_10">
+     <property name="geometry">
+      <rect>
+       <x>0</x>
+       <y>0</y>
+       <width>226</width>
+       <height>160</height>
+      </rect>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>160</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <widget class="caFrame" name="StatusFrame_11">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>19</y>
+        <width>201</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>20</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::Box</enum>
+      </property>
+      <widget class="caLineEdit" name="calineedit_33">
+       <property name="geometry">
+        <rect>
+         <x>100</x>
+         <y>1</y>
+         <width>99</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="channel" stdset="0">
+        <string notr="true">$(SYS):$(Axis)-VelAct</string>
+       </property>
+       <property name="background">
+        <color alpha="222">
+         <red>192</red>
+         <green>192</green>
+         <blue>192</blue>
+        </color>
+       </property>
+       <property name="colorMode">
+        <enum>caLineEdit::Static</enum>
+       </property>
+       <property name="precisionMode">
+        <enum>caLineEdit::Channel</enum>
+       </property>
+       <property name="limitsMode">
+        <enum>caLineEdit::User</enum>
+       </property>
+       <property name="unitsEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+      <widget class="caLabel" name="calabel_57">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>1</y>
+         <width>80</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>VelAct: </string>
+       </property>
+      </widget>
+     </widget>
+     <widget class="caFrame" name="StatusFrame_12">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>40</y>
+        <width>201</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>20</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::Box</enum>
+      </property>
+      <widget class="caLabel" name="calabel_62">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>1</y>
+         <width>80</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>TgtPos: </string>
+       </property>
+      </widget>
+      <widget class="caTextEntry" name="catextentry_13">
+       <property name="geometry">
+        <rect>
+         <x>100</x>
+         <y>1</y>
+         <width>70</width>
+         <height>15</height>
+        </rect>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="readOnly">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string notr="true">$(SYS):$(Axis)-TgtPosCmd</string>
+       </property>
+       <property name="keepFocus">
+        <bool>true</bool>
+       </property>
+      </widget>
+      <widget class="caLineEdit" name="calineedit_35">
+       <property name="geometry">
+        <rect>
+         <x>170</x>
+         <y>2</y>
+         <width>29</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="channel" stdset="0">
+        <string notr="true">$(SYS):$(Axis)-TgtPosCmd.EGU</string>
+       </property>
+       <property name="background">
+        <color alpha="222">
+         <red>192</red>
+         <green>192</green>
+         <blue>192</blue>
+        </color>
+       </property>
+       <property name="colorMode">
+        <enum>caLineEdit::Static</enum>
+       </property>
+       <property name="precisionMode">
+        <enum>caLineEdit::Channel</enum>
+       </property>
+       <property name="limitsMode">
+        <enum>caLineEdit::User</enum>
+       </property>
+       <property name="unitsEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </widget>
+     <widget class="caFrame" name="StatusFrame_13">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>60</y>
+        <width>201</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>20</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::Box</enum>
+      </property>
+      <widget class="caLabel" name="calabel_63">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>1</y>
+         <width>80</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>TgtVel: </string>
+       </property>
+      </widget>
+      <widget class="caTextEntry" name="catextentry_16">
+       <property name="geometry">
+        <rect>
+         <x>100</x>
+         <y>1</y>
+         <width>70</width>
+         <height>15</height>
+        </rect>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="readOnly">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string notr="true">$(SYS):$(Axis)-TgtVelCmd</string>
+       </property>
+       <property name="keepFocus">
+        <bool>true</bool>
+       </property>
+      </widget>
+      <widget class="caLineEdit" name="calineedit_36">
+       <property name="geometry">
+        <rect>
+         <x>170</x>
+         <y>2</y>
+         <width>29</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="channel" stdset="0">
+        <string notr="true">$(SYS):$(Axis)-TgtVelCmd.EGU</string>
+       </property>
+       <property name="background">
+        <color alpha="222">
+         <red>192</red>
+         <green>192</green>
+         <blue>192</blue>
+        </color>
+       </property>
+       <property name="colorMode">
+        <enum>caLineEdit::Static</enum>
+       </property>
+       <property name="precisionMode">
+        <enum>caLineEdit::Channel</enum>
+       </property>
+       <property name="limitsMode">
+        <enum>caLineEdit::User</enum>
+       </property>
+       <property name="unitsEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </widget>
+     <widget class="caFrame" name="StatusFrame_14">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>80</y>
+        <width>201</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>20</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::Box</enum>
+      </property>
+      <widget class="caLabel" name="calabel_46">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>1</y>
+         <width>80</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>type: </string>
+       </property>
+      </widget>
+      <widget class="caMenu" name="camenu_4">
+       <property name="geometry">
+        <rect>
+         <x>100</x>
+         <y>1</y>
+         <width>80</width>
+         <height>18</height>
+        </rect>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="channel" stdset="0">
+        <string notr="true">$(SYS):$(Axis)-MtnCmd</string>
+       </property>
+      </widget>
+     </widget>
+     <widget class="caFrame" name="StatusFrame_15">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>201</width>
+        <height>21</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>20</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::Box</enum>
+      </property>
+      <widget class="caLineEdit" name="calineedit_37">
+       <property name="geometry">
+        <rect>
+         <x>100</x>
+         <y>1</y>
+         <width>99</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="channel" stdset="0">
+        <string notr="true">$(SYS):$(Axis)-PosAct</string>
+       </property>
+       <property name="background">
+        <color alpha="222">
+         <red>192</red>
+         <green>192</green>
+         <blue>192</blue>
+        </color>
+       </property>
+       <property name="colorMode">
+        <enum>caLineEdit::Static</enum>
+       </property>
+       <property name="precisionMode">
+        <enum>caLineEdit::Channel</enum>
+       </property>
+       <property name="limitsMode">
+        <enum>caLineEdit::User</enum>
+       </property>
+       <property name="unitsEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+      <widget class="caLabel" name="calabel_64">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>1</y>
+         <width>80</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>PosAct: </string>
+       </property>
+      </widget>
+     </widget>
+     <widget class="caFrame" name="StatusFrame_16">
+      <property name="geometry">
+       <rect>
+        <x>110</x>
+        <y>100</y>
+        <width>91</width>
+        <height>61</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>20</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::Box</enum>
+      </property>
+      <widget class="caToggleButton" name="catogglebutton_5">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>1</y>
+         <width>51</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>enable</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string notr="true">$(SYS):$(Axis)-EnaCmd</string>
+       </property>
+      </widget>
+      <widget class="caLed" name="caled_3">
+       <property name="geometry">
+        <rect>
+         <x>67</x>
+         <y>1</y>
+         <width>18</width>
+         <height>16</height>
+        </rect>
+       </property>
+       <property name="rectangular">
+        <bool>true</bool>
+       </property>
+       <property name="gradientEnabled">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string notr="true">$(SYS):$(Axis)-EnaAct</string>
+       </property>
+       <property name="trueColor">
+        <color>
+         <red>0</red>
+         <green>85</green>
+         <blue>0</blue>
+        </color>
+       </property>
+      </widget>
+      <widget class="caMessageButton" name="camessagebutton_10">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="geometry">
+        <rect>
+         <x>50</x>
+         <y>20</y>
+         <width>33</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string notr="true">$(SYS):$(Axis)-StpCmd</string>
+       </property>
+       <property name="label">
+        <string notr="true">stop</string>
+       </property>
+       <property name="foreground">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>255</blue>
+        </color>
+       </property>
+       <property name="background">
+        <color>
+         <red>170</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="disabledForeground">
+        <color>
+         <red>170</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="releaseMessage">
+        <string notr="true">1</string>
+       </property>
+       <property name="pressMessage">
+        <string notr="true"/>
+       </property>
+      </widget>
+      <widget class="caMessageButton" name="camessagebutton_12">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>20</y>
+         <width>34</width>
+         <height>21</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>exec</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string notr="true">$(SYS):$(Axis)-ExeCmd</string>
+       </property>
+       <property name="label">
+        <string notr="true">exec</string>
+       </property>
+       <property name="foreground">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>255</blue>
+        </color>
+       </property>
+       <property name="background">
+        <color>
+         <red>0</red>
+         <green>0</green>
+         <blue>127</blue>
+        </color>
+       </property>
+       <property name="disabledForeground">
+        <color>
+         <red>170</red>
+         <green>0</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="disableChannel" stdset="0">
+        <string/>
+       </property>
+       <property name="releaseMessage">
+        <string notr="true">1</string>
+       </property>
+       <property name="pressMessage">
+        <string notr="true">0</string>
+       </property>
+      </widget>
+      <widget class="caMessageButton" name="camessagebutton_4">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>40</y>
+         <width>75</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="channel" stdset="0">
+        <string notr="true">$(SYS):$(Axis)-RstCmd</string>
+       </property>
+       <property name="label">
+        <string notr="true">reset</string>
+       </property>
+       <property name="releaseMessage">
+        <string notr="true">1</string>
+       </property>
+       <property name="pressMessage">
+        <string notr="true"/>
+       </property>
+      </widget>
+     </widget>
+     <widget class="caFrame" name="caframe_3">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>110</y>
+        <width>111</width>
+        <height>41</height>
+       </rect>
+      </property>
+      <property name="background">
+       <color>
+        <red>255</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="backgroundMode">
+       <enum>caFrame::Filled</enum>
+      </property>
+      <property name="visibility">
+       <enum>caFrame::IfNotZero</enum>
+      </property>
+      <property name="channel" stdset="0">
+       <string notr="true">$(SYS):$(Axis)-ErrId</string>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_11">
+       <item row="0" column="0">
+        <widget class="caLabel" name="calabel_4">
+         <property name="text">
+          <string>ERROR</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="foreground">
+          <color>
+           <red>255</red>
+           <green>255</green>
+           <blue>255</blue>
+          </color>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+    <widget class="caFrame" name="StatusFrame_2">
+     <property name="geometry">
+      <rect>
+       <x>0</x>
+       <y>162</y>
+       <width>226</width>
+       <height>50</height>
+      </rect>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>50</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <widget class="caLabel" name="calabel_10">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>18</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>18</width>
+        <height>18</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>#</string>
+      </property>
+     </widget>
+     <widget class="caMessageButton" name="camessagebutton_13">
+      <property name="geometry">
+       <rect>
+        <x>149</x>
+        <y>1</y>
+        <width>70</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>50</width>
+        <height>18</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>error reset</string>
+      </property>
+      <property name="channel" stdset="0">
+       <string notr="true">$(SYS):$(Axis)-ErrRst</string>
+      </property>
+      <property name="label">
+       <string notr="true">error reset</string>
+      </property>
+      <property name="releaseMessage">
+       <string notr="true">0</string>
+      </property>
+      <property name="pressMessage">
+       <string notr="true">1</string>
+      </property>
+      <property name="colorMode">
+       <enum>caMessageButton::Default</enum>
+      </property>
+     </widget>
+     <widget class="caLineEdit" name="calineedit_9">
+      <property name="geometry">
+       <rect>
+        <x>5</x>
+        <y>26</y>
+        <width>190</width>
+        <height>15</height>
+       </rect>
+      </property>
+      <property name="channel" stdset="0">
+       <string notr="true">$(SYS):$(Axis)-MsgTxt</string>
+      </property>
+      <property name="colorMode">
+       <enum>caLineEdit::Default</enum>
+      </property>
+      <property name="alarmHandling">
+       <enum>caLineEdit::onBackground</enum>
+      </property>
+      <property name="precisionMode">
+       <enum>caLineEdit::User</enum>
+      </property>
+     </widget>
+     <widget class="caLineEdit" name="calineedit_6">
+      <property name="geometry">
+       <rect>
+        <x>24</x>
+        <y>1</y>
+        <width>119</width>
+        <height>18</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>25</width>
+        <height>18</height>
+       </size>
+      </property>
+      <property name="channel" stdset="0">
+       <string notr="true">$(SYS):$(Axis)-ErrId</string>
+      </property>
+      <property name="precisionMode">
+       <enum>caLineEdit::User</enum>
+      </property>
+     </widget>
+    </widget>
    </widget>
    <widget class="QWidget" name="tab_2">
     <attribute name="title">
@@ -2724,7 +2750,7 @@
      <x>232</x>
      <y>30</y>
      <width>82</width>
-     <height>381</height>
+     <height>231</height>
     </rect>
    </property>
    <property name="minimumSize">
@@ -2849,7 +2875,7 @@
     </property>
     <property name="font">
      <font>
-      <pointsize>12</pointsize>
+      <pointsize>9</pointsize>
      </font>
     </property>
     <property name="text">


### PR DESCRIPTION
It basically removes layout and let caqtdm does the resize.

Here is the difference (left is the original)
![ecmcAxis_panel_changes](https://github.com/paulscherrerinstitute/ecmccfg/assets/3283924/2dabb855-3cfc-469b-97c1-d119332b6d70)
