### PR TITLE
Cleanup EL70x1 and EL70x7

### DIFF
--- a/hardware/Beckhoff_7XXX/EL/ecmcEL7031.cmd
+++ b/hardware/Beckhoff_7XXX/EL/ecmcEL7031.cmd
@@ -16,9 +16,3 @@ ${SCRIPTEXEC} ${ecmccfg_DIR}slaveVerify.cmd "RESET=true"
 
 #- common PDOs for status and control
 ${SCRIPTEXEC} ${ecmccfg_DIR}ecmcEX70XX.cmd
-
-#- Max full step freq = 2000Hz (setting is 1)
-ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0x5,1,1)"
-
-#- Invert motor polarity = 0
-ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0x9,0,1)"

--- a/hardware/Beckhoff_7XXX/EL/ecmcEL7037.cmd
+++ b/hardware/Beckhoff_7XXX/EL/ecmcEL7037.cmd
@@ -17,14 +17,5 @@ ${SCRIPTEXEC} ${ecmccfg_DIR}slaveVerify.cmd "RESET=true"
 #- common PDOs for status and control
 ${SCRIPTEXEC} ${ecmccfg_DIR}ecmcEX70XX.cmd
 
-#- Max full step freq = 2000Hz (setting is 1)
-ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0x5,1,1)"
-
 #- Error on loss of steps = 1
 ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0xA,1,1)"
-
-#- Feedback type = Internal counter = 1 (for encoder on terminal set to 0)
-ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0x8,1,1)"
-
-#- Invert motor polarity = 0
-ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0x9,0,1)"

--- a/hardware/Beckhoff_7XXX/EL/ecmcEL7041-0052.cmd
+++ b/hardware/Beckhoff_7XXX/EL/ecmcEL7041-0052.cmd
@@ -14,17 +14,5 @@ epicsEnvSet("ECMC_EC_PRODUCT_ID"         "0x1b813052")
 #- verify slave, including reset
 ${SCRIPTEXEC} ${ecmccfg_DIR}slaveVerify.cmd "RESET=true"
 
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x7000,0x01,16,encoderControl01)"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x7000,0x11,16,encoderValue01"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1602,0x7010,0x1,16,driveControl01)"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1604,0x7010,0x21,16,1,velocitySetpoint01)"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x6000,0x0,16,encoderStatus01)"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x6000,0x11,16,positionActual01)"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x6000,0x12,16,encoderLatchPostion01)"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a03,0x6010,0x1,16,driveStatus01)"
-
-#- Max full step freq = 2000Hz (setting is 1)
-ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0x5,1,1)"
-
-#- Invert motor polarity = 0
-ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0x9,0,1)"
+#- common PDOs for status and control
+${SCRIPTEXEC} ${ecmccfg_DIR}ecmcEX70XX.cmd

--- a/hardware/Beckhoff_7XXX/EL/ecmcEL7041-1000.cmd
+++ b/hardware/Beckhoff_7XXX/EL/ecmcEL7041-1000.cmd
@@ -14,14 +14,8 @@ epicsEnvSet("ECMC_EC_PRODUCT_ID"         "0x1b813052")
 #- verify slave, including reset
 ${SCRIPTEXEC} ${ecmccfg_DIR}slaveVerify.cmd "RESET=true"
 
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x7000,0x01,16,encoderControl01)"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x7000,0x11,16,encoderValue01"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1602,0x7010,0x1,16,driveControl01)"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1604,0x7010,0x21,16,1,velocitySetpoint01)"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x6000,0x0,16,encoderStatus01)"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x6000,0x11,16,positionActual01)"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x6000,0x12,16,encoderLatchPostion01)"
-ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a03,0x6010,0x1,16,driveStatus01)"
+#- common PDOs for status and control
+${SCRIPTEXEC} ${ecmccfg_DIR}ecmcEX70XX.cmd
 
 #- -----------------------------------------------------------
 #-  Index 7010 STM Outputs Ch.1

--- a/hardware/Beckhoff_7XXX/EL/ecmcEL7041.cmd
+++ b/hardware/Beckhoff_7XXX/EL/ecmcEL7041.cmd
@@ -16,9 +16,3 @@ ${SCRIPTEXEC} ${ecmccfg_DIR}slaveVerify.cmd "RESET=true"
 
 #- common PDOs for status and control
 ${SCRIPTEXEC} ${ecmccfg_DIR}ecmcEX70XX.cmd
-
-#- Max full step freq = 2000Hz (setting is 1)
-ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0x5,1,1)"
-
-#- Invert motor polarity = 0
-ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0x9,0,1)"

--- a/hardware/Beckhoff_7XXX/EL/ecmcEL7047.cmd
+++ b/hardware/Beckhoff_7XXX/EL/ecmcEL7047.cmd
@@ -17,14 +17,5 @@ ${SCRIPTEXEC} ${ecmccfg_DIR}slaveVerify.cmd "RESET=true"
 #- common PDOs for status and control
 ${SCRIPTEXEC} ${ecmccfg_DIR}ecmcEX70XX.cmd
 
-#- Max full step freq = 2000Hz (setting is 1)
-ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0x5,1,1)"
-
 #- Error on loss of steps = 1
 ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0xA,1,1)"
-
-#- Feedback type = Internal counter = 1 (for encoder on terminal set to 0)
-ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0x8,1,1)"
-
-#- Invert motor polarity = 0
-ecmcConfigOrDie "Cfg.EcAddSdo(${ECMC_EC_SLAVE_NUM},0x8012,0x9,0,1)"


### PR DESCRIPTION
Hi @kivel and @anderssandstrom,

Just a small cleanup. It started with a fix for the missing `)` but then I noticed we are setting the default values on top of the reset. Not sure if you added that on purpose or not. 

Changes:
- Remove "speed range" (default value already is 2000 steps/s)
- Remove "invert motor polarity" (default value already is 0)
- Remove "feedback type" (default value already is 1)
- Use ecmcEX70XX.cmd for EL7041-0052 and EL7041-1000 (also fixes a missing close parenthesis)