### PR TITLE
fix brake bug

### DIFF
--- a/scripts/jinja2/templates/drive.jinja2
+++ b/scripts/jinja2/templates/drive.jinja2
@@ -59,10 +59,10 @@
 {#- scaling #}
 ecmcConfigOrDie "Cfg.SetAxisDrvScaleNum({{ axis.id }},{{ drive.numerator }})"
 ecmcConfigOrDie "Cfg.SetAxisDrvScaleDenom({{ axis.id }},{{ drive.denominator }})"
-{#- Brake #}
+{#- brake #}
 {%- if drive.brake %}
-    ecmcConfigOrDie "Cfg.SetAxisDrvBrakeEnable({{ axis.id }}, {{ drive.brake.enable|int }})"
     ecmcConfigOrDie "Cfg.LinkEcEntryToObject("{{ drive.brake.output }}","ax{{ axis.id }}.drv.brake")"
+    ecmcConfigOrDie "Cfg.SetAxisDrvBrakeEnable({{ axis.id }}, {{ drive.brake.enable|int }})"
     {%- if drive.brake.closeAhead %}
     ecmcConfigOrDie "Cfg.SetAxisDrvBrakeOpenDelayTime({{ axis.id }},{{ drive.brake.openDelay }})"
     {%- endif %}


### PR DESCRIPTION
The order in which the commands for the brake are issued was wrong.
With this fix, the output for the brake is set first, followed by the actual enable command.

fixes #215 