### PR TITLE
add EL5102

### DIFF
--- a/db/Beckhoff_5XXX/ecmcEL5102.substitutions
+++ b/db/Beckhoff_5XXX/ecmcEL5102.substitutions
@@ -1,0 +1,6 @@
+file "ecmcEL5101-0010-chX.template"
+{
+    pattern {CH_ID}
+            {01   }   
+            {02   }   
+}

--- a/hardware/Beckhoff_5XXX/EL/ecmcEL5102.cmd
+++ b/hardware/Beckhoff_5XXX/EL/ecmcEL5102.cmd
@@ -1,0 +1,39 @@
+#-d /** 
+#-d   \brief hardware script for EL5102
+#-d   \details EL5102 Incremental encoder interface (differential RS422) 32 bit support, 2-channel
+#-d   \author Alvin Acerbo
+#-d   \file
+#-d */
+
+epicsEnvSet("ECMC_EC_HWTYPE"             "EL5102")
+epicsEnvSet("ECMC_EC_VENDOR_ID"          "0x2")
+epicsEnvSet("ECMC_EC_PRODUCT_ID"         "0x13ee3052")
+epicsEnvSet("ECMC_EC_COMP_TYPE"          "EL5102")
+
+#- verify slave, including reset
+ecmcFileExist(${ecmccfg_DIR}slaveVerify.cmd,1)
+${SCRIPTEXEC} ${ecmccfg_DIR}slaveVerify.cmd "RESET=${ECMC_SLAVE_RESET=true}"
+
+#- ###########################################################
+#- ############ Config PDOS: Channel 1
+
+ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x7000,0x01,16,encoderControl01)"
+ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x7000,0x11,32,encoderValue01)"
+ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a04,0x6000,0x01,16,encoderStatus01)"
+ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a04,0x6000,0x11,32,positionActual01)"
+ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a04,0x6000,0x12,32,encoderLatchPostion01)"
+
+#- ###########################################################
+#- ############ Config PDOS: Channel 2
+
+ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1606,0x7010,0x01,16,encoderControl02)"
+ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1606,0x7010,0x11,32,encoderValue02)"
+ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a11,0x6010,0x01,16,encoderStatus02)"
+ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a11,0x6010,0x11,32,positionActual02)"
+ecmcConfigOrDie "Cfg.EcAddEntryComplete(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a11,0x6010,0x12,32,encoderLatchPostion02)"
+
+#- Default panel
+epicsEnvSet("ECMC_HW_PANEL"              "EL5102")
+
+#- Cleanup
+epicsEnvUnset(ECMC_SLAVE_RESET)


### PR DESCRIPTION
Adding support for EL5102, which is a 2-channel incremental encoder interface.

This configuration sets up the module in legacy mode, similar to EL5101. In legacy mode, some advanced functionality that the module supports, is not available, such as timestamping.