### PR TITLE
Fix typo in record creation ecmcEKM1101-ACC-Stat.template

### DIFF
--- a/db/Beckhoff_1XXX/ecmcEKM1101-ACC-Stat.template
+++ b/db/Beckhoff_1XXX/ecmcEKM1101-ACC-Stat.template
@@ -59,7 +59,7 @@ record(bi,"${ECMC_P}AccSOvrAlrm"){
   field(FLNK, "${ECMC_P}AccOvrRunAlrm")
 }
 
-record(bi,"${ECMC_P}-AccOvrRunAlrm"){
+record(bi,"${ECMC_P}AccOvrRunAlrm"){
   field(DESC, "$(HWTYPE): Acc Ovrrun")
   field(INP,  "${ECMC_P}AccStat.B5")
   field(ZNAM, "No Alarm")


### PR DESCRIPTION
There is an extra hyphen. This causes a broken CA link in -AccSOvrAlrm.