### PR TITLE
Fix typo in record FLINK ecmcELM360X-stat-chX.template

### DIFF
--- a/db/Beckhoff_3XXX/ecmcELM360X-stat-chX.template
+++ b/db/Beckhoff_3XXX/ecmcELM360X-stat-chX.template
@@ -4,7 +4,7 @@ record(mbbiDirect,"${ECMC_P}${KEY=AI}${CH_ID}-Stat"){
   field(DTYP, "asynUInt32Digital")
   field(INP,  "@asynMask($(PORT),$(ADDR=0),0xFFFF,$(TIMEOUT=1))T_SMP_MS=$(T_SMP_MS=1000)/TYPE=asynUInt32Digital/ec$(MASTER_ID).s$(SLAVE_POS).status${CH_ID}?")
   field(SCAN, "I/O Intr")
-  field(FLNK, "${ECMC_P}${KEY=AI}${CH_ID}-UndrLim-Alrm.PROC")
+  field(FLNK, "${ECMC_P}${KEY=AI}${CH_ID}-UndrLimAlrm.PROC")
   field(TSE,  "$(TSE=-2)")
 }
 


### PR DESCRIPTION
Extra hyphen in a FLNK causes broken link.