### PR TITLE
Remove duplicate of -DbgPrntEna

### DIFF
--- a/db/core/ecmcAxis.db
+++ b/db/core/ecmcAxis.db
@@ -487,16 +487,6 @@ record(bo,"${P}${AXIS_NAME}-SftLimFwdEna"){
 }
 
 record(bo,"${P}${AXIS_NAME}-DbgPrntEna"){
-  field(DESC, "${AXIS_NAME}: Ena dbg prints")
-  field(OUT,  "${P}${AXIS_NAME}-Cmd_.BA")
-  field(ZNAM, "Disable")
-  field(ONAM, "Enable")
-  field(SCAN, "Passive")
-  field(FLNK, "${P}${AXIS_NAME}-Cmd_.PROC")
-  field(TSE,  "0")
-}
-
-record(bo,"${P}${AXIS_NAME}-DbgPrntEna"){
   field(DESC, "${AXIS_NAME}: Enable printouts")
   field(OUT,  "${P}${AXIS_NAME}-Cmd_.BA")
   field(ZNAM, "Disable")


### PR DESCRIPTION
Hi @anderssandstrom ,

noticed this record is defined twice.
Kept the second one.