### PR TITLE
Fix macro substitution inside .substitutions files

### DIFF
--- a/db/core/ecmcDS.substitutions
+++ b/db/core/ecmcDS.substitutions
@@ -1,5 +1,5 @@
-file ecmcDS-idx.template
+file "ecmcDS-idx.template"
 {
   pattern { DS_DATAINDEX_ACT,           DS_DATA_ACT ,             DS_STAT,               DS_TYPE,               DS_STAT_,               DS_FULL,              DS_CLEAR_CMD,           DESC_NAME  }
-          { DS$(Index2Char)-DataIdAct,  DS$(Index2Char)-DataAct,  DS$(Index2Char)-Stat,  DS$(Index2Char)-Type,  DS$(Index2Char)-Stat_,  DS$(Index2Char)-Full, DS$(Index2Char)-ClrCmd, DS$(Index2Char)-Desc }
+          { "DS$(Index2Char)-DataIdAct",  "DS$(Index2Char)-DataAct",  "DS$(Index2Char)-Stat",  "DS$(Index2Char)-Type",  "DS$(Index2Char)-Stat_",  "DS$(Index2Char)-Full", "DS$(Index2Char)-ClrCmd", "DS$(Index2Char)-Desc" }
 }

--- a/db/core/ecmcPlc.substitutions
+++ b/db/core/ecmcPlc.substitutions
@@ -1,5 +1,5 @@
-file ecmcPlc.template
+file "ecmcPlc.template"
 {
   pattern { PLC_ENABLE,               PLC_SCANTIME,               PLC_ERROR,            DESC_NAME}
-          { PLC$(Index2Char)-EnaCmd,  PLC$(Index2Char)-ScanTime,  PLC$(Index2Char)-Err, PLC$(Index2Char)-Desc }
+          { "PLC$(Index2Char)-EnaCmd",  "PLC$(Index2Char)-ScanTime",  "PLC$(Index2Char)-Err", "PLC$(Index2Char)-Desc" }
 }


### PR DESCRIPTION
Hi @anderssandstrom ,

we need double quotes `"` around macros inside _.substitutions_ files as per [EPICS docs](https://docs.epics-controls.org/projects/base/en/latest/msi.html#syntax-for-all-formats).