### PR TITLE
Allow for PREFIX in loadYamlAxis.cmd

### DIFF
--- a/scripts/jinja2/loadYamlAxis.cmd
+++ b/scripts/jinja2/loadYamlAxis.cmd
@@ -6,12 +6,14 @@
 #-d   \author Niko Kivel, Anders Sandström
 #-d   \file
 #-d   \param FILE the yaml-file containing the PLC definition
-#-d   \param DEV  the device name (optional, defaults to ${IOC}
+#-d   \param DEV  the device name (optional, defaults to ${IOC}), automatically appended with a `:`
+#-d   \param PREFIX  the device PREFIX, will _NOT_ be appended with a `:`
 #-d   \note Example calls:
 #-d   \note - call
 #-d   \code
 #-d     ${SCRIPTEXEC} "./loadYamlAxis.cmd" "FILE=./axis1.yaml"
 #-d     ${SCRIPTEXEC} "./loadYamlAxis.cmd" "FILE=./axis1.yaml, DEV=foobar"
+#-d     ${SCRIPTEXEC} "./loadYamlAxis.cmd" "FILE=./axis1.yaml, PREFIX=MTEST-STEPPER:X:"
 #-d   \endcode
 #-d */
 
@@ -43,7 +45,7 @@ system "rm -rf ${FILE_TEMP_2}"
 epicsEnvUnset(FILE_TEMP_2)
 
 #- set device name, default to ${IOC}
-epicsEnvSet("ECMC_PREFIX"      "${DEV=${IOC}}:")
+epicsEnvSet("ECMC_PREFIX"      "${PREFIX=${DEV=${IOC}}:}")
 
 #- check for ECMC-format PLC file and load the PLC
 ecmcFileExist("${FILE_TEMP_3}",1)


### PR DESCRIPTION
At the CLS, the motor PVs do not have a `:` after the device name. To allow proper naming, the auto-append needs to be avoided. To the best of my understanding, this will address the "issue". The user is fully responsible to provide the proper prefix.