### PR TITLE
add config for MX form factor MS2204 EtherCAT Power Infeed module

### DIFF
--- a/db/Beckhoff_2XXX/ecmcMS2204-0002.substitutions
+++ b/db/Beckhoff_2XXX/ecmcMS2204-0002.substitutions
@@ -1,0 +1,25 @@
+file "ecmc_analogInputFloat-chX.template"
+{
+  pattern {CH_ID, KEY, sourceName,  suffix,         EGU, PREC}
+          {01,    CH,  EFU_current, "-EFUCurrent",  "A", 4   }
+          {01,    CH,  PWI_voltage, "-PWIVoltage",  "V", 4   }
+          {01,    CH,  PWI_current, "-PWICurrent",  "A", 4   }
+}
+
+file "ecmc_binaryInput-chX.template"
+{
+  pattern {CH_ID, KEY, sourceName,  suffix,       ZNAM,              ONAM          }
+          {01,    CH,  PWI_warning, "-PWIAlrm",   "No PWI Warning",  "PWI Warning" }
+          {01,    CH,  EFU_warning, "-EFUAlrm",   "No EFU Warning",  "EFU Warning" }
+          {01,    CH,  EFU_error,   "-EFUErr",    "No EFU Error",    "EFU Error"   }
+          {01,    CH,  EFU_tripped, "-EFUTrpd",   "EFU Not Tripped", "EFU Tripped" }
+          {01,    CH,  EFU_enabled, "-EFUEnabld", "EFU Not Enabled", "EFU Enabled" }
+}
+
+file "ecmc_binaryOutput-chX.template"
+{
+  pattern {CH_ID, KEY, sourceName,  suffix       }
+          {01,    CH,  EFU_enable,  "-EFUEnable" }
+          {01,    CH,  EFU_control, "-EFUControl"}
+          {01,    CH,  EFU_reset,   "-EFUReset"  }
+}

--- a/hardware/Beckhoff_2XXX/MS/ecmcMS2204-0002.cmd
+++ b/hardware/Beckhoff_2XXX/MS/ecmcMS2204-0002.cmd
@@ -1,0 +1,44 @@
+#-d /**
+#-d   \brief hardware script for MS2204
+#-d   \details EtherCAT power infeed + forwarding, 24 V DC/4 A
+#-d   \author Alvin Acerbo
+#-d   \file
+#-d */
+
+epicsEnvSet("ECMC_EC_HWTYPE",        "MS2204-0002")
+epicsEnvSet("ECMC_EC_VENDOR_ID",     "0x00000002")
+epicsEnvSet("ECMC_EC_PRODUCT_ID",    "0xa4dedf0b")
+
+#- verify slave
+ecmcFileExist(${ecmccfg_DIR}slaveVerify.cmd,1)
+${SCRIPTEXEC} ${ecmccfg_DIR}slaveVerify.cmd "RESET=1"
+
+
+#- EFU Output Ch.1
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x7000,0x01,B1,EFU_enable01)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x7000,0x02,B1,EFU_control01)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x7000,0x03,B1,EFU_reset01)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x0000,0x00,B1,gap1,0)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x0000,0x00,B4,gap2,0)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},1,2,0x1600,0x0000,0x00,U8,gap3,0)"
+
+#- EFU Inputs Ch.1
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x6000,0x01,B1,EFU_warning01)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x6000,0x02,B1,EFU_error01)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x6000,0x03,B1,EFU_tripped01)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x6000,0x04,B1,EFU_enabled01)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x0000,0x00,B2,gap4,0)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x0000,0x00,U8,gap5,0)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x6000,0x0f,B2,EFU_cycle_counter01)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x0000,0x00,U16,gap6,0)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a00,0x6000,0x12,F32,EFU_current01)"
+
+#- PWI Inputs Ch.1
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a10,0x6010,0x01,B1,PWI_warning01)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a10,0x0000,0x00,U8,gap7,0)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a10,0x0000,0x00,B4,gap8,0)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a10,0x0000,0x00,B1,gap9,0)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a10,0x6010,0x0f,B2,PWI_cycle_counter01)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a10,0x0000,0x00,U16,gap10,0)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a10,0x6010,0x12,F32,PWI_voltage01)"
+ecmcConfigOrDie "Cfg.EcAddEntryDT(${ECMC_EC_SLAVE_NUM},${ECMC_EC_VENDOR_ID},${ECMC_EC_PRODUCT_ID},2,3,0x1a10,0x6010,0x13,F32,PWI_current01)"


### PR DESCRIPTION
This is a configuration file for the MX form factor MS2204 module. This module supplies the MX baseplates and integrate the MX-System into the EtherCAT bus. This configuration file maps the default PDOs.

Since there will be plenty more MS form factor modules, I suggest a new configuration file subdirectories akin to EL, EP, etc: The new ones for now seems to be:
MB - baseplate
MO - I/O
MD - Drive
MR - relay
MS - system